### PR TITLE
feat(release): add release-publish composite action

### DIFF
--- a/actions/release-publish/README.md
+++ b/actions/release-publish/README.md
@@ -1,0 +1,127 @@
+# `release-publish` composite action
+
+Generate Conventional-Commit release notes via [git-cliff][cliff] and
+publish a single-shot, [Immutable-Releases][imm]–compatible GitHub
+Release. Optional asset upload and preset notes blocks.
+
+[cliff]: https://git-cliff.org/
+[imm]: https://docs.github.com/repositories/releasing-projects-on-github/about-releases#immutable-releases
+
+## Why a composite action (and not a reusable workflow)?
+
+Reusable workflows run with the OIDC subject of *the workflow file's
+repository*. That breaks `actions/attest-build-provenance` when the
+attestation needs to verify against the *caller's* repo. Composite
+actions run inside the caller's job, inheriting its OIDC subject —
+which is what consumers expect when they run
+`gh attestation verify ... --repo <owner>/<caller-repo>`.
+
+Move the build + attestation steps into the caller, then call this
+action to publish.
+
+## Inputs
+
+| Name           | Required | Default            | Description                                                                  |
+| -------------- | -------- | ------------------ | ---------------------------------------------------------------------------- |
+| `mise-version` | yes      | —                  | mise version to install. Used to provision `git-cliff`.                       |
+| `tag`          | yes      | —                  | Git tag (e.g. `v1.2.0`). Usually `${{ github.ref_name }}`.                    |
+| `assets`       | no       | `""`               | Newline-delimited list of file paths to attach. No globbing — be explicit.    |
+| `extra-notes`  | no       | `""`               | Preset key for an appended notes block. See [Presets](#presets).              |
+| `github-token` | no       | `${{ github.token }}` | Token used by `gh release create`.                                       |
+
+## Presets
+
+| Key      | Effect                                                                                |
+| -------- | ------------------------------------------------------------------------------------- |
+| `""`     | No extra notes (default).                                                             |
+| `log-sh` | Appends the standard `log.sh` consumption snippet + attestation-verification snippet. |
+
+Add new presets here when a recurring asset-distribution pattern shows up
+in two or more repos.
+
+## Caller responsibilities
+
+- Check out the repo *before* calling this action (`actions/checkout` with
+  `fetch-depth: 0` so `git-cliff` can see history).
+- Set job permissions yourself: at minimum `contents: write`. Add
+  `id-token: write` and `attestations: write` if you also call
+  `actions/attest-build-provenance` in the same job.
+- Build any artifacts and call `attest-build-provenance` *before* this
+  action so the attestation is bound to the caller's OIDC.
+
+## Example — notes-only release
+
+```yaml
+name: Release
+on: { push: { tags: ['v*'] } }
+permissions: { contents: read }
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0, persist-credentials: false }
+      - uses: DevSecNinja/.github/actions/release-publish@<sha>
+        with:
+          mise-version: "2026.4.9"
+          tag: ${{ github.ref_name }}
+```
+
+## Example — assets + attestations + preset notes
+
+```yaml
+name: Release
+on: { push: { tags: ['v*'] } }
+permissions: { contents: read }
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0, persist-credentials: false }
+
+      - name: Build artifacts
+        run: ./script/build-log-sh-release.sh "${{ github.ref_name }}" dist
+
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            dist/log.sh
+            dist/log-sh-${{ github.ref_name }}.tar.gz
+
+      - uses: DevSecNinja/.github/actions/release-publish@<sha>
+        with:
+          mise-version: "2026.4.9"
+          tag: ${{ github.ref_name }}
+          extra-notes: log-sh
+          assets: |
+            dist/log.sh
+            dist/log.sh.sha256
+            dist/log-sh-${{ github.ref_name }}.tar.gz
+            dist/log-sh-${{ github.ref_name }}.tar.gz.sha256
+```
+
+## Pitfalls baked in
+
+These are the lessons captured in `DevSecNinja/dotfiles`'s
+`commit-and-release` skill — encoded into the composite so consumers don't
+have to re-learn them:
+
+- **`gh release create` is single-shot.** Notes, title, and all assets go
+  in one call. No later `gh release upload --clobber` or
+  `gh release edit` (rejected on Immutable-Releases repos).
+- **`git-cliff` is invoked with `--latest --strip all`** for fleet-wide
+  consistency. Don't override per-repo.
+- **Attestation must stay in the caller**, never inside this action.
+- **Asset list is literal, not globbed**, so the audit trail is the YAML.

--- a/actions/release-publish/action.yml
+++ b/actions/release-publish/action.yml
@@ -1,0 +1,130 @@
+---
+name: Release publish
+description: |
+  Generate Conventional-Commit release notes via git-cliff and create an
+  immutable GitHub Release. Optionally attach assets and append a preset
+  notes block describing how to consume them.
+
+  This is a composite action so that any preceding `actions/attest-build-provenance`
+  step in the caller's job stays bound to the caller's OIDC subject.
+  See: https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+
+inputs:
+  mise-version:
+    description: "mise version to install (used to provision git-cliff)"
+    required: true
+  tag:
+    description: "Git tag to release (e.g. v1.2.0). Usually github.ref_name."
+    required: true
+  assets:
+    description: |
+      Newline-delimited list of file paths to attach to the release.
+      Empty for a notes-only release. Glob patterns are NOT expanded —
+      pass concrete paths so that the upload set is auditable.
+    required: false
+    default: ""
+  extra-notes:
+    description: |
+      Optional preset key whose canned notes block is appended to the
+      auto-generated changelog. Supported values:
+        - ""       (default — no extra notes)
+        - log-sh   (appends the standard log.sh consumption +
+                    attestation-verification snippet)
+    required: false
+    default: ""
+  github-token:
+    description: "Token for gh CLI. Defaults to the workflow's GITHUB_TOKEN."
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install mise
+      # renovate: datasource=github-tags depName=jdx/mise-action
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      with:
+        install: true
+        cache: false
+        version: ${{ inputs.mise-version }}
+
+    - name: Generate release notes
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        REPO: ${{ github.repository }}
+        EXTRA: ${{ inputs.extra-notes }}
+      run: |
+        set -euo pipefail
+        # Always: --latest (just this tag's slice) + --strip all (no header,
+        # no footer, no version heading — pure body suitable for a Release).
+        mise exec -- git-cliff --latest --strip all > /tmp/release-notes.md
+
+        case "${EXTRA}" in
+          "")
+            ;;
+          log-sh)
+            {
+              printf '\n---\n\n'
+              printf '## log.sh distribution\n\n'
+              printf 'This release includes a vendorable copy of `log.sh`. See '
+              printf '[docs/logging.md](https://github.com/%s/blob/%s/docs/logging.md#consuming-logsh-from-other-repositories) ' \
+                "${REPO}" "${TAG}"
+              printf 'for the consumption snippet.\n\n'
+              printf '```sh\n'
+              printf 'curl -fsSL https://github.com/%s/releases/download/%s/log.sh -o scripts/lib/log.sh\n' \
+                "${REPO}" "${TAG}"
+              printf 'curl -fsSL https://github.com/%s/releases/download/%s/log.sh.sha256 -o scripts/lib/log.sh.sha256\n' \
+                "${REPO}" "${TAG}"
+              printf '( cd scripts/lib && sha256sum -c log.sh.sha256 )\n'
+              printf '```\n\n'
+              printf '### Verifying provenance\n\n'
+              printf 'Each binary asset is attested via [GitHub Artifact Attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). '
+              printf 'Verify with the GitHub CLI:\n\n'
+              printf '```sh\n'
+              printf 'gh attestation verify ./log.sh --repo %s\n' "${REPO}"
+              printf 'gh attestation verify ./log-sh-%s.tar.gz --repo %s\n' "${TAG}" "${REPO}"
+              printf '```\n'
+            } >> /tmp/release-notes.md
+            ;;
+          *)
+            printf 'Unknown extra-notes preset: %s\n' "${EXTRA}" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Create immutable GitHub Release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        TAG: ${{ inputs.tag }}
+        REPO: ${{ github.repository }}
+        ASSETS: ${{ inputs.assets }}
+      run: |
+        set -euo pipefail
+
+        # Convert newline-delimited assets into a bash array, stripping
+        # blank/whitespace-only lines (so trailing newlines in YAML don't
+        # turn into spurious "" arguments to gh).
+        asset_args=()
+        while IFS= read -r line; do
+          trimmed="${line#"${line%%[![:space:]]*}"}"
+          trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+          [ -n "${trimmed}" ] && asset_args+=("${trimmed}")
+        done <<< "${ASSETS}"
+
+        # Single-shot upload: notes, title, and assets in one call so the
+        # release is compatible with the repo's Immutable-Releases setting
+        # (no later `gh release upload --clobber` / `gh release edit`).
+        if [ ${#asset_args[@]} -gt 0 ]; then
+          gh release create "${TAG}" \
+            --repo "${REPO}" \
+            --title "${TAG}" \
+            --notes-file /tmp/release-notes.md \
+            "${asset_args[@]}"
+        else
+          gh release create "${TAG}" \
+            --repo "${REPO}" \
+            --title "${TAG}" \
+            --notes-file /tmp/release-notes.md
+        fi


### PR DESCRIPTION
## Summary

Adds a new `actions/release-publish` composite action that encodes the canonical fleet release-publish flow:

1. Install mise (provisioning git-cliff)
2. Generate release notes via `git-cliff --latest --strip all` (enforced — fleet consistency)
3. Optionally append a preset notes block (`extra-notes: log-sh` for now)
4. Create an Immutable-Releases compatible GitHub Release in a single `gh release create` call, with optional newline-delimited assets

## Why a composite action and not a reusable workflow extension?

Reusable workflows execute under the OIDC subject of the *workflow's* repo, which breaks `actions/attest-build-provenance` verification against the caller. Composite actions run inside the caller's job and inherit its OIDC subject, so attestations verify correctly with `gh attestation verify ... --repo <owner>/<caller-repo>`.

This was a hard-won lesson in `DevSecNinja/dotfiles` (recorded in its `commit-and-release` skill) — encoding it here means consumers can't accidentally relearn it.

## Compatibility

- **The existing `.github/workflows/release.yml` reusable workflow is unchanged.** Simple callers (e.g. `truenas-apps`) keep working with zero diff.
- New / asset-shipping consumers (e.g. `dotfiles`) call this composite directly and own their checkout + build + attest steps.

## Built-in pitfalls

- `git-cliff --latest --strip all` is enforced (no per-repo override knob)
- `gh release create` is single-shot (no later `--clobber` or `edit`) — Immutable-Releases compatible
- Asset list is literal, not globbed — audit trail lives in the caller YAML
- Newline-stripping when parsing the `assets` input so trailing YAML newlines don't pass `""` to `gh`

## Files

- `actions/release-publish/action.yml` — the composite
- `actions/release-publish/README.md` — usage docs with both notes-only and assets+attestations examples

## Follow-up

Companion PR in `DevSecNinja/dotfiles` will swap its inline `release.yml` to call this action with `extra-notes: log-sh`. Once that lands and a release is cut + verified, the `dotfiles` workflow becomes the reference implementation for any other repo that needs the heavier flow.