### PR TITLE
feat(release): add release-please reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,81 @@
+---
+name: Reusable — Release Please
+
+# Drives semver bumping and CHANGELOG.md generation via release-please.
+# On every push to the target branch, this workflow either:
+#
+#   1. Opens (or force-updates) a release PR titled
+#      `chore(<scope>): release <version>` containing the chore commit
+#      and CHANGELOG.md update for the next semver derived from
+#      Conventional Commits since the last tag.
+#
+#   2. When that release PR is merged, creates the `vX.Y.Z` git tag
+#      pointing at the merge commit. **It does NOT create a GitHub
+#      Release** (skip-github-release: true is set in each consumer's
+#      release-please-config.json) — publishing is owned by the
+#      consumer's existing tag-triggered `release.yml`.
+#
+# Branch protection is fully respected: the chore commit always lands
+# via PR through normal CI. No bypass actor is needed.
+#
+# See: https://github.com/googleapis/release-please-action
+
+on:
+  workflow_call:
+    inputs:
+      target-branch:
+        description: "Branch to track (defaults to main)."
+        required: false
+        type: string
+        default: main
+      config-file:
+        description: "Path to release-please-config.json (relative to repo root)."
+        required: false
+        type: string
+        default: release-please-config.json
+      manifest-file:
+        description: "Path to .release-please-manifest.json (relative to repo root)."
+        required: false
+        type: string
+        default: .release-please-manifest.json
+    outputs:
+      releases_created:
+        description: "`true` when this run created at least one new tag."
+        value: ${{ jobs.release-please.outputs.releases_created }}
+      tag_name:
+        description: "Tag created by release-please (e.g. `v1.2.0`), if any."
+        value: ${{ jobs.release-please.outputs.tag_name }}
+      pr:
+        description: "PR JSON for the open release-PR, if any."
+        value: ${{ jobs.release-please.outputs.pr }}
+
+permissions:
+  contents: read
+
+jobs:
+  release-please:
+    name: Open or update release PR
+    runs-on: ubuntu-24.04
+    permissions:
+      # release-please needs to push the chore-release branch and tag.
+      contents: write
+      # …and to open / update the release PR.
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
+      pr: ${{ steps.release-please.outputs.pr }}
+    steps:
+      - name: Run release-please
+        id: release-please
+        # renovate: datasource=github-releases depName=googleapis/release-please-action
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        with:
+          target-branch: ${{ inputs.target-branch }}
+          config-file: ${{ inputs.config-file }}
+          manifest-file: ${{ inputs.manifest-file }}
+          # GITHUB_TOKEN is sufficient when the workflow has
+          # contents: write + pull-requests: write (set at job level
+          # above). Repos that need cross-branch labels or
+          # extra-files updates outside the manifest can pass a PAT
+          # via `secrets.token` and we'll wire it up here.

--- a/workflow-templates/release-please.properties.json
+++ b/workflow-templates/release-please.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Release Please",
+  "description": "Open / update release-PRs and create tags from Conventional Commits via release-please. Replaces local cog bump.",
+  "iconName": "release-please",
+  "categories": ["Automation", "Release"],
+  "filePatterns": [".release-please-manifest.json", "release-please-config.json"]
+}

--- a/workflow-templates/release-please.yml
+++ b/workflow-templates/release-please.yml
@@ -1,0 +1,30 @@
+---
+name: Release Please
+
+# Drives semver bumping via release-please. On every push to main this
+# workflow opens (or updates) a release PR with the next version's
+# CHANGELOG bump. Merging that PR creates the `vX.Y.Z` tag, which
+# triggers this repo's existing tag-triggered release workflow.
+#
+# Per-repo config:
+#   - release-please-config.json
+#   - .release-please-manifest.json
+#
+# See the reusable for details:
+# https://github.com/DevSecNinja/.github/blob/main/.github/workflows/release-please.yml
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-please:
+    uses: DevSecNinja/.github/.github/workflows/release-please.yml@v1.0.0
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

Adds a reusable `release-please.yml` workflow that drives semver bumping fleet-wide via [googleapis/release-please-action][rp]. Consumers get a 10-line caller workflow + two small repo-config files; everything else lives here.

[rp]: https://github.com/googleapis/release-please-action

## Why release-please

Replaces local `cog bump → git push origin main` (which requires a branch-protection bypass for every release) with a **release-PR pattern**:

1. Push `feat/fix/chore` commits to `main` as usual via PRs.
2. release-please opens (or updates) a `chore: release vX.Y.Z` PR with the cumulative CHANGELOG bump.
3. Merge that PR through normal CI + branch protection → release-please creates the `vX.Y.Z` tag.
4. Tag push triggers each consumer's existing tag-triggered release workflow (notes-only via the existing `release.yml` reusable, or assets+attestations via the new `release-publish` composite added in #32).

**Branch protection is honoured. No bypass actor required.**

## Inputs / outputs

| Input | Default | Purpose |
| --- | --- | --- |
| `target-branch` | `main` | Branch release-please tracks |
| `config-file` | `release-please-config.json` | Per-repo policy file |
| `manifest-file` | `.release-please-manifest.json` | Per-repo current-version pin |

| Output | Purpose |
| --- | --- |
| `releases_created` | `true` when this run cut a new tag |
| `tag_name` | The new tag, if any |
| `pr` | JSON for the open release PR, if any |

## Why `skip-github-release: true` is mandatory in consumer configs

release-please *can* create a GitHub Release itself, but:

- Repos with assets (e.g. `dotfiles`) need the existing tag-triggered workflow to call `release-publish` for build-provenance attestations. Two creates of the same release on an Immutable-Releases repo would clash.
- Repos without assets (e.g. `truenas-apps`) already use the simple reusable `release.yml` for the notes-only release.

In both cases the *publishing* path is unchanged. release-please only handles **bump + tag**.

The reusable enforces this implicitly by *not* passing any "create-release" input — the actual gate lives in each consumer's `release-please-config.json` (`"skip-github-release": true`). The README that follows in the consumer PRs makes this explicit.

## Workflow-template

Also adds `workflow-templates/release-please.yml` so repos can adopt it via the "New workflow" picker in the GitHub UI.

## Versioning

The template currently pins `@v1.0.0` because that's the org's existing release tag here. After this PR merges and you cut a new release of `DevSecNinja/.github` (e.g. `v1.1.0`), bump the template's pin in a follow-up PR — Renovate will propose this automatically.

## Follow-up PRs

- `DevSecNinja/dotfiles` — adopt release-please, retire `task release:bump` / cog pre-bump hooks, update skill + copilot-instructions
- `DevSecNinja/truenas-apps` — adopt release-please, same retirement