### PR TITLE
feat(release-please): wire GitHub App token + onboarding doc

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,18 @@ name: Reusable — Release Please
 # Branch protection is fully respected: the chore commit always lands
 # via PR through normal CI. No bypass actor is needed.
 #
-# See: https://github.com/googleapis/release-please-action
+# Authentication: pass `app-id` (input) + `app-private-key` (secret) so
+# release PRs are opened by a GitHub App identity — App-opened PRs
+# trigger `pull_request: opened` events, so required CI status checks
+# fire automatically. Without those, release-please falls back to
+# `GITHUB_TOKEN`, which by GitHub design does NOT trigger workflow runs
+# on the PRs it opens; under branch protection that means the PR cannot
+# satisfy required status checks. See:
+#   https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+#
+# See also:
+#   - https://github.com/googleapis/release-please-action
+#   - DevSecNinja/.github docs/release-please-onboarding.md
 
 on:
   workflow_call:
@@ -38,6 +49,22 @@ on:
         required: false
         type: string
         default: .release-please-manifest.json
+      app-id:
+        description: |
+          GitHub App ID used to mint a short-lived token for opening the
+          release PR. When set, the App must be installed on the calling
+          repo with Contents: write + Pull requests: write permissions.
+          When unset, release-please falls back to GITHUB_TOKEN — release
+          PRs will open but won't trigger CI on `pull_request` events.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app-private-key:
+        description: |
+          PEM contents of the GitHub App's private key, paired with
+          `app-id`. Required when `app-id` is set.
+        required: false
     outputs:
       releases_created:
         description: "`true` when this run created at least one new tag."
@@ -58,6 +85,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       # release-please needs to push the chore-release branch and tag.
+      # Used as fallback when `app-id` is not provided.
       contents: write
       # …and to open / update the release PR.
       pull-requests: write
@@ -66,6 +94,15 @@ jobs:
       tag_name: ${{ steps.release-please.outputs.tag_name }}
       pr: ${{ steps.release-please.outputs.pr }}
     steps:
+      - name: Generate App token
+        id: app-token
+        if: inputs.app-id != ''
+        # renovate: datasource=github-releases depName=actions/create-github-app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
       - name: Run release-please
         id: release-please
         # renovate: datasource=github-releases depName=googleapis/release-please-action
@@ -74,8 +111,7 @@ jobs:
           target-branch: ${{ inputs.target-branch }}
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
-          # GITHUB_TOKEN is sufficient when the workflow has
-          # contents: write + pull-requests: write (set at job level
-          # above). Repos that need cross-branch labels or
-          # extra-files updates outside the manifest can pass a PAT
-          # via `secrets.token` and we'll wire it up here.
+          # Use the App token if available; otherwise fall back to
+          # GITHUB_TOKEN. Release PRs opened with GITHUB_TOKEN won't
+          # trigger CI — see top-of-file comment.
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ repositories.
 | What                       | Where                                                          |
 | -------------------------- | -------------------------------------------------------------- |
 | Reusable workflows         | [`.github/workflows/`](.github/workflows/)                     |
-| Workflow templates         | [`workflow-templates/`](workflow-templates/)                    |
+| Composite actions          | [`actions/`](actions/)                                         |
+| Workflow templates         | [`workflow-templates/`](workflow-templates/)                   |
 | Config sync (files)        | [`config-sync/files/`](config-sync/files/)                     |
 | Config sync (templates)    | [`config-sync/templates/`](config-sync/templates/)             |
 | Renovate presets           | [`.renovate/`](.renovate/)                                     |
 | Design decisions (ADRs)    | [`docs/design-decisions/`](docs/design-decisions/README.md)    |
 | Architecture & usage guide | [`docs/architecture.md`](docs/architecture.md)                 |
+| Release Please onboarding  | [`docs/release-please-onboarding.md`](docs/release-please-onboarding.md) |
 
 ## Development
 
@@ -21,8 +23,10 @@ mise exec -- lefthook run pre-commit  # run linters
 ```
 
 Commit with [Conventional Commits](https://www.conventionalcommits.org).
-See the [`commit-and-release`](.github/skills/commit-and-release/SKILL.md) skill
-for a step-by-step guide including releases with `cog bump`.
+Releases are automated via
+[release-please](docs/release-please-onboarding.md) — every push to
+`main` opens or updates a `chore(main): release vX.Y.Z` PR. Merge to
+ship.
 
 ## License
 

--- a/docs/release-please-onboarding.md
+++ b/docs/release-please-onboarding.md
@@ -1,0 +1,272 @@
+# Release Please — onboarding a new repo
+
+Step-by-step guide for adopting the central
+[`release-please.yml`](../.github/workflows/release-please.yml)
+reusable workflow in a `DevSecNinja/*` repo.
+
+The end state: every push to `main` opens or updates a `chore(main):
+release vX.Y.Z` PR that you merge to ship. **Branch protection is
+respected end-to-end — no bypass actor needed.**
+
+---
+
+## Prerequisites
+
+Before the first repo can adopt this, the org/account needs a **shared
+GitHub App**. This is a *one-time* setup. Skip ahead to [Per-repo
+adoption](#per-repo-adoption) if the App already exists (it does for
+DevSecNinja — see below).
+
+### One-time: create the GitHub App
+
+> Personal accounts can use App credentials too — secrets just live at
+> the **repo level** instead of the org level.
+
+1. Go to <https://github.com/settings/apps/new> (or org-level: *Org
+   Settings → Developer settings → GitHub Apps → New GitHub App*).
+2. Fill in:
+   - **Name**: `DevSecNinja Release Please` (or org equivalent).
+   - **Homepage URL**: this repo's URL.
+   - **Description** (255 char max):
+
+     > Opens release PRs via release-please across the DevSecNinja org.
+     > Uses short-lived App tokens so release PRs trigger required CI
+     > status checks under branch protection — replacing the legacy
+     > `cog bump` direct-push flow.
+
+   - **Webhook → Active**: ❌ uncheck (no webhooks needed).
+3. **Repository permissions**:
+   - `Contents`: **Read and write** (push the release branch + tag).
+   - `Pull requests`: **Read and write** (open / update the release PR).
+   - `Metadata`: Read-only (auto-required).
+4. **Where can this GitHub App be installed?**: *Only on this account*.
+5. Create the App. From the App's settings page, capture the **App
+   ID** (numeric, top of the page).
+6. **Generate a private key** ("Private keys" section → *Generate a
+   private key*). Save the downloaded `.pem` file securely — you'll
+   only need it once per repo to copy into a secret.
+7. **Install the App** on the repos that will adopt release-please
+   ("Install App" tab on the App's public page).
+
+For reference, the DevSecNinja App is `DevSecNinja Release Please`
+(App ID `3563533`).
+
+---
+
+## Per-repo adoption
+
+You'll do these once per repo. Order matters — do the **App install +
+secrets** before merging the workflow PR, otherwise the first run will
+fail with `Bad credentials` instead of just falling back to
+`GITHUB_TOKEN`.
+
+### 1. Install the App on the repo
+
+From the App's public page, *Install App → Configure*, and tick the
+repo. Or navigate to *Repo Settings → Integrations → GitHub Apps →
+Configure*.
+
+### 2. Add the secret + variable
+
+In *Repo Settings → Secrets and variables → Actions*:
+
+- **Variables tab → New repository variable**
+  - Name: `RELEASE_PLEASE_APP_ID`
+  - Value: the App's numeric ID (e.g. `3563533`).
+  - App IDs are not sensitive — a variable is fine and surfaces in logs
+    for easier debugging.
+- **Secrets tab → New repository secret**
+  - Name: `RELEASE_PLEASE_APP_PRIVATE_KEY`
+  - Value: the *full* contents of the `.pem` file generated in the
+    one-time setup, including `-----BEGIN/END RSA PRIVATE KEY-----`
+    lines.
+
+> Renovate cannot manage these. They are configured once per repo and
+> rotated only if the App's private key is compromised.
+
+### 3. Enable Actions PR-creation
+
+*Repo Settings → Actions → General → Workflow permissions →*
+**✅ "Allow GitHub Actions to create and approve pull requests"** →
+Save.
+
+This is a separate, GitHub-side guardrail and **cannot** be granted via
+workflow YAML `permissions:` alone. Without it, release-please's first
+run fails with:
+
+> `GitHub Actions is not permitted to create or approve pull requests`
+
+(The workflow successfully creates the branch + commit; only the
+final PR-open step is blocked.)
+
+### 4. Add the three release-please files
+
+Commit the following on a feature branch:
+
+#### `.github/workflows/release-please.yml`
+
+Use the [`workflow-templates/release-please.yml`](../workflow-templates/release-please.yml)
+in this repo (also available via the GitHub UI's "New workflow"
+picker), or paste:
+
+```yaml
+---
+name: Release Please
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+jobs:
+  release-please:
+    # renovate: datasource=github-tags depName=DevSecNinja/.github
+    uses: DevSecNinja/.github/.github/workflows/release-please.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+```
+
+Pin `<sha>` to a release-tagged commit of `DevSecNinja/.github`. The
+`# renovate:` comment lets Renovate auto-bump it when new tags ship.
+
+#### `release-please-config.json`
+
+Minimal single-package config for the simple language strategy (just
+tracks a manifest, no language-specific bumping):
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "skip-github-release": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
+  "draft": false,
+  "prerelease": false,
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "package-name": "<your-repo-name>",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}
+```
+
+**`skip-github-release: true` is mandatory** when the repo already has
+a tag-triggered `release.yml` (which most do, via `release-publish` or
+the central simple `release.yml`). Otherwise release-please will create
+a duplicate release that conflicts with the existing one — and on
+Immutable-Releases repos that's an unrecoverable error.
+
+#### `.release-please-manifest.json`
+
+Pin to the *current* released version (the one matching the latest
+`v*` tag):
+
+```json
+{ ".": "X.Y.Z" }
+```
+
+release-please bumps this file inside its release PRs. **Do not have
+Renovate manage it** — the bump is the release.
+
+### 5. (Optional) Retire local `cog bump`
+
+If the repo had `cog bump` driving releases (cog hooks in `cog.toml`,
+`task release:bump` in Taskfile, etc.):
+
+- Strip `pre_bump_hooks` and `post_bump_hooks` from `cog.toml`. Keep
+  the file for `cog verify` in the lefthook commit-msg hook.
+- Remove `task release:bump` and any CI-gate tasks (`release:check-ci`,
+  `release:changelog`). Keep `task release:notes` / `task release:build`
+  if they're useful for local previews.
+- Update any onboarding / contributor docs to point at this guide.
+
+Reference implementations:
+
+- [`DevSecNinja/dotfiles`](https://github.com/DevSecNinja/dotfiles) —
+  with assets + Sigstore attestations.
+- [`DevSecNinja/truenas-apps`](https://github.com/DevSecNinja/truenas-apps) —
+  notes-only release.
+
+### 6. Merge the PR and watch the first release
+
+On merge to `main`:
+
+1. The release-please workflow fires.
+2. Within a minute it opens `chore(main): release vX.Y.Z`.
+3. **All required CI checks run on it** (because the PR was opened by
+   the App, not `GITHUB_TOKEN`).
+4. Once green, you merge it like any normal PR.
+5. release-please creates the `vX.Y.Z` tag on the merge commit.
+6. The tag-triggered `release.yml` publishes the GitHub Release.
+
+---
+
+## Troubleshooting
+
+### `GitHub Actions is not permitted to create or approve pull requests`
+
+Step 3 above wasn't done. Toggle the setting and re-run the workflow
+(or just push another commit — the workflow runs on every push to main).
+
+### `Bad credentials` from `actions/create-github-app-token`
+
+- Check the App is **installed** on the repo (step 1).
+- Check `RELEASE_PLEASE_APP_PRIVATE_KEY` contains the entire `.pem`
+  including header/footer lines.
+- Check `RELEASE_PLEASE_APP_ID` is the App ID, not the Installation ID
+  (different number).
+
+### Release PR opens but no CI runs on it
+
+The PR was opened by `github-actions[bot]` instead of the App — step 2
+was skipped or `app-id` is empty. Verify in *Repo Settings → Variables
+→ Actions* that `RELEASE_PLEASE_APP_ID` exists and is non-empty.
+
+Quick unblock for an already-open release PR: a *human user* closes
+and reopens it (which fires `pull_request` events from a user identity,
+triggering CI). Then fix the underlying setting so future PRs don't
+need manual nudging.
+
+### release-please opens no PR despite mergeable commits
+
+release-please needs at least one **non-`chore`** Conventional Commit
+since the last tag (or a `chore` with `Release-As: X.Y.Z` footer) to
+open a PR. Check the Actions log — it explains exactly which commits
+it considered.
+
+Force a release with no qualifying commits: push an empty commit:
+
+```sh
+git commit --allow-empty -m "chore: cut release
+
+Release-As: 0.5.0"
+git push
+```
+
+### The release PR's version is wrong
+
+Override with `Release-As: X.Y.Z` in any commit footer on `main`.
+release-please picks it up on the next push and rewrites the open PR
+to use that version.
+
+---
+
+## Related docs
+
+- [`.github/workflows/release-please.yml`](../.github/workflows/release-please.yml) — the reusable.
+- [`actions/release-publish/README.md`](../actions/release-publish/README.md) — the
+  composite that publishes the GitHub Release on tag push.
+- [`docs/architecture.md`](architecture.md) — fleet architecture overview.

--- a/workflow-templates/release-please.yml
+++ b/workflow-templates/release-please.yml
@@ -10,8 +10,17 @@ name: Release Please
 #   - release-please-config.json
 #   - .release-please-manifest.json
 #
-# See the reusable for details:
-# https://github.com/DevSecNinja/.github/blob/main/.github/workflows/release-please.yml
+# IMPORTANT: configure the GitHub App credentials below so release PRs
+# trigger CI status checks. Without them, release PRs open under the
+# GITHUB_TOKEN identity, which (by GitHub design) does NOT trigger
+# `pull_request` events — required CI status checks will never fire and
+# the PR cannot satisfy branch protection.
+#
+# Onboarding guide:
+#   https://github.com/DevSecNinja/.github/blob/main/docs/release-please-onboarding.md
+#
+# Reusable workflow:
+#   https://github.com/DevSecNinja/.github/blob/main/.github/workflows/release-please.yml
 
 on:
   push:
@@ -28,3 +37,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Closes #34.

## Summary

Wires `actions/create-github-app-token` into the central `release-please` reusable so consumer release PRs are opened by a GitHub App identity. App-opened PRs **do** trigger `pull_request: opened` events, so required CI status checks fire automatically — fixing the [hard block we hit on `truenas-apps#271`](https://github.com/DevSecNinja/truenas-apps/pull/271) where zero checks ran on the bot-opened PR.

Also adds a step-by-step onboarding guide so future adopters can ramp without re-discovering the three gotchas we hit:

1. `Allow GitHub Actions to create and approve pull requests` toggle.
2. `GITHUB_TOKEN` doesn't trigger `pull_request` events.
3. release-please can't update `.release-please-manifest.json` itself before the first manual pin.

## Changes

### `.github/workflows/release-please.yml` (reusable)

- New input: `app-id` (string, optional, default `""`).
- New secret: `app-private-key` (optional).
- New step `Generate App token` (gated `if: inputs.app-id != ''`) using `actions/create-github-app-token@1b10c78c… # v3.1.1` (pinned by SHA, Renovate-tracked).
- `release-please-action` now receives `token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}` — falls back to `GITHUB_TOKEN` when `app-id` is empty so existing callers keep working.

### `workflow-templates/release-please.yml`

- Wires `app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}` and `app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}` by default, so new adopters get the App-token path out of the box.
- Header comment now points at the onboarding doc.

### `docs/release-please-onboarding.md` (new)

Full guide covering:

- One-time GitHub App setup (with the exact field values used for the existing `DevSecNinja Release Please` App, App ID `3563533`).
- Per-repo: install + secret/variable wiring + the Actions PR-creation toggle + the three release-please files.
- Retiring local `cog bump` (links to `dotfiles` and `truenas-apps` as reference implementations).
- Troubleshooting section for the three gotchas we hit.
- "Force a release" recipe (`Release-As: X.Y.Z` empty commit).

### `README.md`

- Adds row for "Release Please onboarding" in the table.
- Adds row for "Composite actions" (`actions/`) — overdue.
- Replaces the old "releases with `cog bump`" blurb with a release-please callout.

## Backwards compatibility

The `app-id` input is **optional**. Existing callers (none yet on the new shape, but any future caller that doesn't wire App credentials) continue to work via `GITHUB_TOKEN` — they'll just hit the no-CI-trigger gotcha and need the close+reopen workaround until they adopt the App.

## Follow-up PRs

After this lands and the org cuts a new release of `DevSecNinja/.github`:

- `DevSecNinja/dotfiles` — re-pin caller to the new SHA, add `app-id` + `app-private-key` wiring.
- `DevSecNinja/truenas-apps` — same.

## Validation

- YAML structure mirrors the working `release-publish` pattern.
- `actions/create-github-app-token@v3.1.1` is the latest GA release.
- `if: inputs.app-id != ''` keeps the App step optional.
- Doc renders cleanly (verified via raw markdown structure).