### PR TITLE
chore(deps): bump release-please-action to v5.0.0 (Node 24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run release-please
         id: release-please
         # renovate: datasource=github-releases depName=googleapis/release-please-action
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           target-branch: ${{ inputs.target-branch }}
           config-file: ${{ inputs.config-file }}


### PR DESCRIPTION
## Summary

Bumps the pinned version of `googleapis/release-please-action` from `v4.4.1` (Node 20) to `v5.0.0` (Node 24) inside the central reusable workflow.

## Why

The first successful release-please run on this repo emitted:

> `Node.js 20 actions are deprecated. […] Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.`

`v5.0.0` (released 2026-04-22) is the Node 24 successor. Per its release notes, the only breaking change is the runtime; inputs and outputs are unchanged so this is a drop-in pin bump.

Release notes: https://github.com/googleapis/release-please-action/releases/tag/v5.0.0

## Validation

- Inputs/outputs unchanged → no caller adjustments needed across the fleet.
- Renovate hint comment kept; future updates auto-tracked.
- This caller currently pins `@main`; once this lands, the next run will use v5.0.0 transparently.