### PR TITLE
feat(labels): rename automerge to `merge: auto` and add release-please labels

### DIFF
--- a/.github/labels-base.yaml
+++ b/.github/labels-base.yaml
@@ -26,8 +26,20 @@
   color: "f6412d"
 
 # Automation
-- name: automerge
+- name: "merge: auto"
   color: "0075ca"
+  description: PR is eligible for automerge
+  aliases:
+    - automerge
+- name: "merge: manual"
+  color: "5319e7"
+  description: PR requires manual review and merge
+- name: "autorelease: pending"
+  color: "ededed"
+  description: Release Please — release pending
+- name: "autorelease: tagged"
+  color: "0e8a16"
+  description: Release Please — release tagged
 - name: config-sync
   color: "0075ca"
 - name: todo-to-issue

--- a/.renovate/labels.json5
+++ b/.renovate/labels.json5
@@ -41,14 +41,20 @@
       description: "Label all PRs that will be auto-merged",
       matchUpdateTypes: ["minor", "patch"],
       matchCurrentVersion: "!/^0\\./",
-      addLabels: ["automerge"],
+      addLabels: ["merge: auto"],
     },
     {
       description: "Label trusted GitHub Actions auto-merge PRs (including 0.x)",
       matchManagers: ["github-actions"],
       matchPackageNames: ["/^actions\\//", "/^docker\\//", "/^github\\//"],
       matchUpdateTypes: ["minor", "patch"],
-      addLabels: ["automerge"],
+      addLabels: ["merge: auto"],
+    },
+    {
+      description: "Label GitHub Actions pinDigest PRs (auto-merged via SHA pinning)",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["pinDigest"],
+      addLabels: ["merge: auto"],
     },
   ],
 }


### PR DESCRIPTION
## Summary

- Rename `automerge` → `merge: auto` (uses `aliases:` so EndBug/label-sync renames the existing label rather than deleting/recreating it, preserving history on tagged PRs/issues).
- Add `merge: manual` for PRs that require manual review and merge.
- Add `autorelease: pending` and `autorelease: tagged` (introduced by Release Please, previously without colors).
- Update Renovate `labels.json5` to apply the new `merge: auto` label.
- Add an explicit `pinDigest` rule for GitHub Actions so SHA-pin PRs get the label (this is what was missing on #35).

## Colors

| Label | Color |
| --- | --- |
| `merge: auto` | `#0075ca` (kept) |
| `merge: manual` | `#5319e7` |
| `autorelease: pending` | `#ededed` |
| `autorelease: tagged` | `#0e8a16` |
