### PR TITLE
feat(open-pr): add composite action to open or update PRs from working tree

### DIFF
--- a/actions/open-pr/README.md
+++ b/actions/open-pr/README.md
@@ -1,0 +1,142 @@
+# `open-pr` composite action
+
+Open (or update) a pull request from the current working tree.
+
+After your job has produced changes to commit (signed scripts, formatted
+files, regenerated configs, …), this action stages them, commits them
+to a stable working branch, force-pushes, and opens a PR via the
+preinstalled `gh` CLI. Repeat runs reuse the same PR rather than
+spamming new ones.
+
+Designed for jobs that should land via PR review instead of pushing
+directly to a protected branch — auto-formatting, artifact signing,
+generated-content updates, etc. Branch protection on the base branch
+stays fully enforced; no bypass actor required.
+
+## Why a composite action (and not a reusable workflow)?
+
+Composite actions run inside the caller's job, so they see the working
+tree the caller just modified. A reusable workflow runs on its own
+runner without access to those uncommitted changes.
+
+This action also avoids pulling in third-party `create-pull-request`
+actions: it uses only `git` and the `gh` CLI that ship preinstalled on
+GitHub-hosted runners.
+
+## Inputs
+
+| Name             | Required | Default                                              | Description                                                                                                                                                                              |
+| ---------------- | -------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `branch`         | yes      | —                                                    | Working branch to create or force-push to. Use a stable per-purpose name (e.g. `chore/sign-powershell-scripts`) so repeat runs reuse the same PR.                                        |
+| `base`           | no       | `main`                                               | Branch to merge into.                                                                                                                                                                    |
+| `title`          | yes      | —                                                    | PR title (also default commit message). Should be a Conventional Commit subject.                                                                                                         |
+| `body`           | no       | `""`                                                 | PR body, plain Markdown.                                                                                                                                                                 |
+| `commit-message` | no       | `title`                                              | Commit message for the staged changes. Defaults to `title`.                                                                                                                              |
+| `paths`          | no       | `.`                                                  | Newline-delimited pathspecs to `git add`. Globs are forwarded literally.                                                                                                                 |
+| `labels`         | no       | `""`                                                 | Newline-delimited labels to apply on PR creation.                                                                                                                                        |
+| `draft`          | no       | `false`                                              | Open as draft.                                                                                                                                                                           |
+| `signoff`        | no       | `false`                                              | Add a `Signed-off-by` trailer to the commit.                                                                                                                                             |
+| `if-no-changes`  | no       | `skip`                                               | Behaviour when there's nothing to commit: `skip` (exit 0) or `fail` (exit non-zero).                                                                                                     |
+| `git-user-name`  | no       | `github-actions[bot]`                                | Author name for the commit.                                                                                                                                                              |
+| `git-user-email` | no       | `41898282+github-actions[bot]@users.noreply.github.com` | Author email for the commit.                                                                                                                                                          |
+| `github-token`   | no       | `${{ github.token }}`                                | Token used for the `git push` and `gh` API call. The default `GITHUB_TOKEN` will NOT retrigger workflows on the bot's push, which is what you want inside loops like signing-on-push. Pass a PAT/App token for cross-repo PRs or to retrigger CI on the new branch. |
+
+## Outputs
+
+| Name        | Description                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------- |
+| `changed`   | `true` when there were uncommitted changes and a PR was opened or updated.                               |
+| `created`   | `true` when a brand-new PR was opened, `false` when an existing PR for `branch` was reused, or no change. |
+| `pr-number` | PR number. Empty when `changed=false`.                                                                   |
+| `pr-url`    | PR URL. Empty when `changed=false`.                                                                      |
+
+## Caller responsibilities
+
+- Check out the repo before calling this action (`actions/checkout`).
+- Set job permissions yourself: at minimum `contents: write` and
+  `pull-requests: write`.
+- Make whatever changes you want committed to the working tree before
+  invoking the action.
+
+## Pitfalls baked in
+
+- **No third-party action dependency.** Only `git` + `gh`, both
+  preinstalled on GitHub-hosted runners.
+- **Default `GITHUB_TOKEN` does not retrigger workflows on push.** Safe
+  inside loops where the same workflow would otherwise re-run on the
+  bot's commit (e.g. sign-on-push).
+- **Force-push with `--force-with-lease`** so a concurrent push to the
+  working branch is not silently overwritten.
+- **PR reuse on conflict.** If a PR already exists for the same
+  `branch -> base` pair, its contents are updated by the force-push
+  and the existing PR is reused — no duplicate PRs across runs.
+- **Branch protection stays enforced.** This action only ever pushes
+  to the working branch and opens a PR; merging into the protected
+  base branch is left to the normal review/automerge flow.
+
+## Example — sign artifacts and open a PR
+
+```yaml
+name: Sign Scripts
+on:
+  push:
+    branches: [main]
+    paths: ['**.ps1']
+
+jobs:
+  sign:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - name: Sign scripts
+        shell: pwsh
+        run: ./sign.ps1   # leaves modified .ps1 files in the working tree
+
+      - uses: DevSecNinja/.github/actions/open-pr@<sha>
+        with:
+          branch: chore/sign-scripts
+          base: main
+          title: 'chore: sign scripts'
+          paths: '**/*.ps1'
+          labels: |
+            automated
+            chore
+          body: |
+            Automated signing of scripts after merge to `main`.
+
+            Triggered by commit ${{ github.sha }}.
+```
+
+## Example — auto-formatter
+
+```yaml
+- run: ./script/format.sh   # rewrites files in place
+
+- uses: DevSecNinja/.github/actions/open-pr@<sha>
+  with:
+    branch: chore/auto-format
+    title: 'style: auto-format'
+    labels: automated
+    if-no-changes: skip   # default
+```
+
+## Example — regenerate manifest, fail if no drift detected
+
+Useful when you *expect* the regeneration to produce changes (because
+something else in the pipeline implies they should exist).
+
+```yaml
+- run: ./script/regen-manifest.sh
+
+- uses: DevSecNinja/.github/actions/open-pr@<sha>
+  with:
+    branch: chore/regen-manifest
+    title: 'chore: regenerate manifest'
+    paths: 'manifest.json'
+    if-no-changes: fail
+```

--- a/actions/open-pr/action.yml
+++ b/actions/open-pr/action.yml
@@ -1,0 +1,249 @@
+---
+name: Open pull request
+description: |
+  Open (or update) a pull request from the current working tree.
+
+  Stages, commits, and force-pushes any uncommitted changes in the
+  caller's checkout to a dedicated working branch, then opens a PR
+  against the target branch via the `gh` CLI. If a PR for that branch
+  already exists (e.g. a previous run that hasn't been merged yet), the
+  force-push updates its contents and the existing PR is reused.
+
+  This is a composite action so it can act on the caller's working tree
+  (a reusable workflow runs in its own job and would not see those
+  changes). Uses only the preinstalled `gh` CLI — no third-party action
+  dependency.
+
+  Designed for jobs like:
+    - signing artifacts then committing them back through PR review,
+    - auto-formatters that should land via PR rather than a direct push,
+    - generated-content updates (labels, configs, manifests).
+
+  Branch protection on the base branch stays fully enforced — the bot
+  opens a PR and a human (or auto-merge with required checks) merges it.
+  No bypass actor required.
+
+inputs:
+  branch:
+    description: |
+      Name of the working branch to create or force-push to. Choose a
+      stable per-purpose name (e.g. `chore/sign-powershell-scripts`) so
+      repeat runs reuse the same PR rather than opening duplicates.
+    required: true
+  base:
+    description: "Branch to merge into. Defaults to `main`."
+    required: false
+    default: main
+  title:
+    description: "Pull request title. Should be a Conventional Commit subject."
+    required: true
+  body:
+    description: |
+      Pull request body. Plain Markdown. Empty by default. The caller is
+      responsible for any context, links, or trigger metadata they want
+      shown in the PR description.
+    required: false
+    default: ""
+  commit-message:
+    description: |
+      Commit message for the staged changes. Defaults to `title` so the
+      commit and PR titles match. Provide a different value if the body
+      of the commit should differ from the PR description.
+    required: false
+    default: ""
+  paths:
+    description: |
+      Newline-delimited list of pathspecs to stage with `git add`. Glob
+      patterns are forwarded to `git add` literally. Defaults to `.`
+      (stage everything in the working tree).
+    required: false
+    default: "."
+  labels:
+    description: |
+      Newline-delimited list of labels to apply on PR creation. Labels
+      that don't yet exist on the repo are skipped by `gh` with a
+      warning. Empty by default.
+    required: false
+    default: ""
+  draft:
+    description: "Open the PR as a draft."
+    required: false
+    default: "false"
+  signoff:
+    description: "Add a `Signed-off-by` trailer to the commit."
+    required: false
+    default: "false"
+  if-no-changes:
+    description: |
+      What to do when there is nothing to commit:
+        - `skip` (default): exit 0 and set `changed=false`.
+        - `fail`: exit non-zero so the calling job fails loudly.
+    required: false
+    default: skip
+  git-user-name:
+    description: "Author name for the commit."
+    required: false
+    default: "github-actions[bot]"
+  git-user-email:
+    description: "Author email for the commit."
+    required: false
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
+  github-token:
+    description: |
+      Token used by `gh` for the PR API call. Defaults to the workflow's
+      GITHUB_TOKEN, which is enough for same-repo PRs and intentionally
+      will NOT retrigger workflows on the bot's push (so this action is
+      safe to use inside loops like sign-on-push).
+
+      Pass a PAT or App token if you need cross-repo PRs or want the
+      bot's push to retrigger CI on the new branch.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  changed:
+    description: "`true` when there were uncommitted changes and a PR was opened or updated."
+    value: ${{ steps.commit.outputs.changed }}
+  pr-number:
+    description: "Number of the PR that was opened or reused. Empty when changed=false."
+    value: ${{ steps.pr.outputs.pr-number }}
+  pr-url:
+    description: "URL of the PR that was opened or reused. Empty when changed=false."
+    value: ${{ steps.pr.outputs.pr-url }}
+  created:
+    description: |
+      `true` when a brand-new PR was opened by this run, `false` when
+      an existing PR for `branch` was reused (its contents updated via
+      force-push), or when changed=false.
+    value: ${{ steps.pr.outputs.created }}
+
+runs:
+  using: composite
+  steps:
+    - name: Stage and commit changes
+      id: commit
+      shell: bash
+      env:
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        BRANCH: ${{ inputs.branch }}
+        BASE: ${{ inputs.base }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        TITLE: ${{ inputs.title }}
+        PATHS: ${{ inputs.paths }}
+        SIGNOFF: ${{ inputs.signoff }}
+        IF_NO_CHANGES: ${{ inputs.if-no-changes }}
+        # Use the supplied token for the push so the bot identity is
+        # consistent with the gh CLI call below.
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        git config user.name  "${GIT_USER_NAME}"
+        git config user.email "${GIT_USER_EMAIL}"
+
+        # Stash any unstaged changes onto a fresh branch rooted at the
+        # current commit so each run produces a clean, single-commit PR
+        # rather than accumulating history on top of a stale branch.
+        git checkout -B "${BRANCH}"
+
+        # Forward `paths` to `git add` as separate arguments. An empty
+        # element (e.g. trailing newline) is filtered out.
+        add_args=()
+        while IFS= read -r line; do
+          trimmed="${line#"${line%%[![:space:]]*}"}"
+          trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+          [ -n "${trimmed}" ] && add_args+=("${trimmed}")
+        done <<< "${PATHS}"
+        if [ "${#add_args[@]}" -eq 0 ]; then
+          add_args=(".")
+        fi
+        git add -- "${add_args[@]}"
+
+        if git diff --cached --quiet; then
+          echo "No staged changes for ${BRANCH}."
+          echo "changed=false" >> "${GITHUB_OUTPUT}"
+          if [ "${IF_NO_CHANGES}" = "fail" ]; then
+            echo "::error::if-no-changes=fail and there is nothing to commit." >&2
+            exit 1
+          fi
+          exit 0
+        fi
+
+        msg="${COMMIT_MESSAGE:-${TITLE}}"
+        commit_args=(-m "${msg}")
+        if [ "${SIGNOFF}" = "true" ]; then
+          commit_args+=(--signoff)
+        fi
+        git commit "${commit_args[@]}"
+
+        # Push with --force-with-lease so we never clobber a branch that
+        # someone else moved between the local checkout and the push.
+        git push --force-with-lease origin "${BRANCH}"
+
+        echo "changed=true" >> "${GITHUB_OUTPUT}"
+
+    - name: Open or reuse pull request
+      id: pr
+      if: steps.commit.outputs.changed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        BRANCH: ${{ inputs.branch }}
+        BASE: ${{ inputs.base }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        LABELS: ${{ inputs.labels }}
+        DRAFT: ${{ inputs.draft }}
+      run: |
+        set -euo pipefail
+
+        # Build label flags from newline-delimited input.
+        label_args=()
+        while IFS= read -r line; do
+          trimmed="${line#"${line%%[![:space:]]*}"}"
+          trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+          [ -n "${trimmed}" ] && label_args+=(--label "${trimmed}")
+        done <<< "${LABELS}"
+
+        draft_args=()
+        if [ "${DRAFT}" = "true" ]; then
+          draft_args+=(--draft)
+        fi
+
+        # Try to create. If a PR already exists for `head:branch -> base`,
+        # `gh pr create` exits non-zero — fall back to looking it up.
+        if gh pr create \
+            --base "${BASE}" \
+            --head "${BRANCH}" \
+            --title "${TITLE}" \
+            --body  "${BODY}" \
+            "${label_args[@]}" \
+            "${draft_args[@]}" \
+            > /tmp/gh-pr-create.out 2>&1; then
+          url=$(tail -n1 /tmp/gh-pr-create.out)
+          number=$(gh pr view "${BRANCH}" --json number --jq '.number')
+          echo "created=true" >> "${GITHUB_OUTPUT}"
+          echo "pr-url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "pr-number=${number}" >> "${GITHUB_OUTPUT}"
+          echo "Opened PR #${number}: ${url}"
+        else
+          # Surface the original error for debuggability, then try reuse.
+          cat /tmp/gh-pr-create.out
+          existing=$(gh pr list \
+            --base "${BASE}" \
+            --head "${BRANCH}" \
+            --state open \
+            --json number,url \
+            --jq '.[0]')
+          if [ -z "${existing}" ] || [ "${existing}" = "null" ]; then
+            echo "::error::gh pr create failed and no existing open PR found for ${BRANCH} -> ${BASE}." >&2
+            exit 1
+          fi
+          number=$(printf '%s' "${existing}" | jq -r '.number')
+          url=$(printf '%s' "${existing}"    | jq -r '.url')
+          echo "created=false" >> "${GITHUB_OUTPUT}"
+          echo "pr-url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "pr-number=${number}" >> "${GITHUB_OUTPUT}"
+          echo "Reused existing PR #${number}: ${url} (force-pushed updated contents)."
+        fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ repositories use it.
 │   ├── copilot-instructions.md   # Org-wide Copilot coding standards
 │   └── labels-base.yaml          # Base label set synced to all repos
 ├── .renovate/              # Renovate shared preset fragments
+├── actions/                # Composite actions (run inside the caller's job)
 ├── config-sync/
 │   ├── files/              # Files auto-synced to every repo (read-only)
 │   └── templates/          # Starting-point files — copy & adapt per repo
@@ -189,6 +190,98 @@ jobs:
       contents: read
       issues: write
 ```
+
+---
+
+## Composite actions
+
+Composite actions live in `actions/` and run **inside the caller's job**.
+Use them when the action needs to operate on the caller's working tree,
+OIDC subject, or pre-existing job state — things a reusable workflow
+(which runs on its own runner) cannot see.
+
+Pin the `uses:` ref to a full commit SHA with a version comment, just
+like reusable workflows.
+
+### Open PR (`actions/open-pr/`)
+
+Opens (or force-updates) a pull request from the current working tree.
+Use it whenever a job has produced changes that should land via PR
+review rather than a direct push to a protected branch — signing,
+formatting, generated-content updates.
+
+Key properties:
+
+- Uses only the preinstalled `gh` CLI; no third-party action.
+- Default `GITHUB_TOKEN` does not retrigger workflows on the bot's
+  push, so it is safe inside loops like sign-on-push.
+- Reuses the existing PR (force-pushes its branch) when one already
+  exists for the same `branch -> base` pair, so repeat runs do not
+  spam duplicate PRs.
+- Branch protection on the base branch stays fully enforced.
+
+| Input            | Required | Default                 | Description                                                                |
+| ---------------- | -------- | ----------------------- | -------------------------------------------------------------------------- |
+| `branch`         | yes      | —                       | Working branch to create or force-push to.                                 |
+| `title`          | yes      | —                       | PR title (also default commit message). Conventional Commit subject.       |
+| `base`           | no       | `main`                  | Branch to merge into.                                                      |
+| `body`           | no       | `""`                    | PR body (Markdown).                                                        |
+| `commit-message` | no       | `title`                 | Override the commit message.                                               |
+| `paths`          | no       | `.`                     | Newline-delimited pathspecs to `git add`.                                  |
+| `labels`         | no       | `""`                    | Newline-delimited labels.                                                  |
+| `draft`          | no       | `false`                 | Open as draft.                                                             |
+| `signoff`        | no       | `false`                 | Add `Signed-off-by` trailer.                                               |
+| `if-no-changes`  | no       | `skip`                  | `skip` = exit 0; `fail` = error when nothing to commit.                    |
+| `git-user-name`  | no       | `github-actions[bot]`   | Commit author name.                                                        |
+| `git-user-email` | no       | github-actions[bot] noreply | Commit author email.                                                   |
+| `github-token`   | no       | `${{ github.token }}`   | Token for `git push` and `gh`. Override with PAT/App for cross-repo PRs.   |
+
+Outputs: `changed`, `created`, `pr-number`, `pr-url`.
+
+**Example caller — sign artifacts and open a PR:**
+
+```yaml
+name: Sign Scripts
+on:
+  push:
+    branches: [main]
+    paths: ['**.ps1']
+
+jobs:
+  sign:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - name: Sign scripts
+        shell: pwsh
+        run: ./sign.ps1
+
+      - uses: DevSecNinja/.github/actions/open-pr@<sha>
+        with:
+          branch: chore/sign-scripts
+          title: 'chore: sign scripts'
+          paths: '**/*.ps1'
+          labels: |
+            automated
+            chore
+```
+
+See [`actions/open-pr/README.md`](../actions/open-pr/README.md) for full
+documentation and more examples.
+
+### Release publish (`actions/release-publish/`)
+
+Generates Conventional-Commit release notes via `git-cliff` and creates
+an immutable GitHub Release with optional asset upload and preset notes
+blocks. Composite (not reusable workflow) so any preceding
+`actions/attest-build-provenance` step in the caller's job stays bound
+to the caller's OIDC subject. See
+[`actions/release-publish/README.md`](../actions/release-publish/README.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a reusable `open-pr` composite action to this repo so consuming
repositories can land bot-generated changes via PR review instead of
pushing directly to a protected branch — without pulling in a third-party
`create-pull-request` action.

## Why a composite action (not a reusable workflow)?

It needs to act on the **caller's working tree**. A reusable workflow
runs on its own runner and does not see uncommitted changes. Mirrors
the existing `actions/release-publish/` pattern in this repo.

## What it does

Stages a configurable pathspec, commits with a configurable
message/author, force-pushes a working branch, then opens a PR via the
preinstalled `gh` CLI. If a PR already exists for the same
`branch -> base` pair, the force-push updates its contents and the
existing PR is reused (no duplicate PRs across repeat runs).

Defaults to the workflow's `GITHUB_TOKEN`, so the bot's commit does NOT
retrigger workflows on the new branch — this is what you want inside
loops like sign-on-push. Override with a PAT or App token for cross-repo
PRs or to retrigger CI.

## Inputs

| Input            | Required | Default                                                  | Purpose |
| ---------------- | -------- | -------------------------------------------------------- | ------- |
| `branch`         | yes      | —                                                        | Working branch to create / force-push |
| `title`          | yes      | —                                                        | PR title (default commit message) |
| `base`           | no       | `main`                                                   | Target branch |
| `body`           | no       | `""`                                                     | PR body Markdown |
| `commit-message` | no       | `title`                                                  | Override commit message |
| `paths`          | no       | `.`                                                      | Newline-delimited `git add` pathspecs |
| `labels`         | no       | `""`                                                     | Newline-delimited labels |
| `draft`          | no       | `false`                                                  | Open as draft |
| `signoff`        | no       | `false`                                                  | `Signed-off-by` trailer |
| `if-no-changes`  | no       | `skip`                                                   | `skip` or `fail` when nothing to commit |
| `git-user-name`  | no       | `github-actions[bot]`                                    | Commit author name |
| `git-user-email` | no       | `41898282+github-actions[bot]@users.noreply.github.com`  | Commit author email |
| `github-token`   | no       | `${{ github.token }}`                                    | Token for `git push` and `gh` |

Outputs: `changed`, `created`, `pr-number`, `pr-url`.

## Files

- `actions/open-pr/action.yml` — the composite action.
- `actions/open-pr/README.md` — full reference + worked examples
  (signing artifacts, auto-formatter, regenerated manifest with
  `if-no-changes: fail`).
- `docs/architecture.md` — adds an **`actions/`** entry to the repo
  layout and a new **Composite actions** section documenting `open-pr`
  alongside `release-publish`.

## Validation

- `actionlint` only lints workflow YAML, not composite action YAML — but
  YAML schema validates clean (composite using runs, all referenced
  inputs/outputs wired, all step names listed).
- `shellcheck` on the extracted bash bodies: clean except two SC2129
  style warnings (consecutive `>> $GITHUB_OUTPUT` redirects). I left
  them as-is for readability; happy to fold them into a single block
  if you prefer.

## First consumer

[DevSecNinja/dotfiles#254](https://github.com/DevSecNinja/dotfiles/pull/254)
will be updated to consume this action once it merges and is tagged.
That replaces an inline ~50-line `gh pr create` block with a single
`uses:` invocation and unblocks the broken `Sign PowerShell Scripts`
workflow run from #253.

## Release-please consequence

This is a `feat:` so release-please will bump the next minor on merge.