### PR TITLE
docs: add workflow trigger conventions reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 Org-level GitHub configuration and shared automation for all **DevSecNinja**
 repositories.
 
-| What                       | Where                                                          |
-| -------------------------- | -------------------------------------------------------------- |
-| Reusable workflows         | [`.github/workflows/`](.github/workflows/)                     |
-| Composite actions          | [`actions/`](actions/)                                         |
-| Workflow templates         | [`workflow-templates/`](workflow-templates/)                   |
-| Config sync (files)        | [`config-sync/files/`](config-sync/files/)                     |
-| Config sync (templates)    | [`config-sync/templates/`](config-sync/templates/)             |
-| Renovate presets           | [`.renovate/`](.renovate/)                                     |
-| Design decisions (ADRs)    | [`docs/design-decisions/`](docs/design-decisions/README.md)    |
-| Architecture & usage guide | [`docs/architecture.md`](docs/architecture.md)                 |
-| Release Please onboarding  | [`docs/release-please-onboarding.md`](docs/release-please-onboarding.md) |
+| What                         | Where                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| Reusable workflows           | [`.github/workflows/`](.github/workflows/)                                     |
+| Composite actions            | [`actions/`](actions/)                                                         |
+| Workflow templates           | [`workflow-templates/`](workflow-templates/)                                   |
+| Config sync (files)          | [`config-sync/files/`](config-sync/files/)                                     |
+| Config sync (templates)      | [`config-sync/templates/`](config-sync/templates/)                             |
+| Renovate presets             | [`.renovate/`](.renovate/)                                                     |
+| Design decisions (ADRs)      | [`docs/design-decisions/`](docs/design-decisions/README.md)                    |
+| Architecture & usage guide   | [`docs/architecture.md`](docs/architecture.md)                                 |
+| Release Please onboarding    | [`docs/release-please-onboarding.md`](docs/release-please-onboarding.md)       |
+| Workflow trigger conventions | [`docs/workflow-trigger-conventions.md`](docs/workflow-trigger-conventions.md) |
 
 ## Development
 

--- a/docs/release-please-onboarding.md
+++ b/docs/release-please-onboarding.md
@@ -13,8 +13,7 @@ respected end-to-end — no bypass actor needed.**
 ## Prerequisites
 
 Before the first repo can adopt this, the org/account needs a **shared
-GitHub App**. This is a *one-time* setup. Skip ahead to [Per-repo
-adoption](#per-repo-adoption) if the App already exists (it does for
+GitHub App**. This is a _one-time_ setup. Skip ahead to [Per-repo adoption](#per-repo-adoption) if the App already exists (it does for
 DevSecNinja — see below).
 
 ### One-time: create the GitHub App
@@ -22,8 +21,8 @@ DevSecNinja — see below).
 > Personal accounts can use App credentials too — secrets just live at
 > the **repo level** instead of the org level.
 
-1. Go to <https://github.com/settings/apps/new> (or org-level: *Org
-   Settings → Developer settings → GitHub Apps → New GitHub App*).
+1. Go to <https://github.com/settings/apps/new> (or org-level: _Org
+   Settings → Developer settings → GitHub Apps → New GitHub App_).
 2. Fill in:
    - **Name**: `DevSecNinja Release Please` (or org equivalent).
    - **Homepage URL**: this repo's URL.
@@ -39,11 +38,11 @@ DevSecNinja — see below).
    - `Contents`: **Read and write** (push the release branch + tag).
    - `Pull requests`: **Read and write** (open / update the release PR).
    - `Metadata`: Read-only (auto-required).
-4. **Where can this GitHub App be installed?**: *Only on this account*.
+4. **Where can this GitHub App be installed?**: _Only on this account_.
 5. Create the App. From the App's settings page, capture the **App
    ID** (numeric, top of the page).
-6. **Generate a private key** ("Private keys" section → *Generate a
-   private key*). Save the downloaded `.pem` file securely — you'll
+6. **Generate a private key** ("Private keys" section → _Generate a
+   private key_). Save the downloaded `.pem` file securely — you'll
    only need it once per repo to copy into a secret.
 7. **Install the App** on the repos that will adopt release-please
    ("Install App" tab on the App's public page).
@@ -62,13 +61,13 @@ fail with `Bad credentials` instead of just falling back to
 
 ### 1. Install the App on the repo
 
-From the App's public page, *Install App → Configure*, and tick the
-repo. Or navigate to *Repo Settings → Integrations → GitHub Apps →
-Configure*.
+From the App's public page, _Install App → Configure_, and tick the
+repo. Or navigate to _Repo Settings → Integrations → GitHub Apps →
+Configure_.
 
 ### 2. Add the secret + variable
 
-In *Repo Settings → Secrets and variables → Actions*:
+In _Repo Settings → Secrets and variables → Actions_:
 
 - **Variables tab → New repository variable**
   - Name: `RELEASE_PLEASE_APP_ID`
@@ -77,7 +76,7 @@ In *Repo Settings → Secrets and variables → Actions*:
     for easier debugging.
 - **Secrets tab → New repository secret**
   - Name: `RELEASE_PLEASE_APP_PRIVATE_KEY`
-  - Value: the *full* contents of the `.pem` file generated in the
+  - Value: the _full_ contents of the `.pem` file generated in the
     one-time setup, including `-----BEGIN/END RSA PRIVATE KEY-----`
     lines.
 
@@ -86,7 +85,7 @@ In *Repo Settings → Secrets and variables → Actions*:
 
 ### 3. Enable Actions PR-creation
 
-*Repo Settings → Actions → General → Workflow permissions →*
+_Repo Settings → Actions → General → Workflow permissions →_
 **✅ "Allow GitHub Actions to create and approve pull requests"** →
 Save.
 
@@ -171,7 +170,7 @@ Immutable-Releases repos that's an unrecoverable error.
 
 #### `.release-please-manifest.json`
 
-Pin to the *current* released version (the one matching the latest
+Pin to the _current_ released version (the one matching the latest
 `v*` tag):
 
 ```json
@@ -212,6 +211,11 @@ On merge to `main`:
 5. release-please creates the `vX.Y.Z` tag on the merge commit.
 6. The tag-triggered `release.yml` publishes the GitHub Release.
 
+> Trigger downstream release workflows on `push: tags`, **not** on
+> `release: created` — see
+> [Release flow with release-please](workflow-trigger-conventions.md#release-flow-with-release-please)
+> for the rationale.
+
 ---
 
 ## Troubleshooting
@@ -232,10 +236,10 @@ Step 3 above wasn't done. Toggle the setting and re-run the workflow
 ### Release PR opens but no CI runs on it
 
 The PR was opened by `github-actions[bot]` instead of the App — step 2
-was skipped or `app-id` is empty. Verify in *Repo Settings → Variables
-→ Actions* that `RELEASE_PLEASE_APP_ID` exists and is non-empty.
+was skipped or `app-id` is empty. Verify in _Repo Settings → Variables
+→ Actions_ that `RELEASE_PLEASE_APP_ID` exists and is non-empty.
 
-Quick unblock for an already-open release PR: a *human user* closes
+Quick unblock for an already-open release PR: a _human user_ closes
 and reopens it (which fires `pull_request` events from a user identity,
 triggering CI). Then fix the underlying setting so future PRs don't
 need manual nudging.
@@ -269,4 +273,6 @@ to use that version.
 - [`.github/workflows/release-please.yml`](../.github/workflows/release-please.yml) — the reusable.
 - [`actions/release-publish/README.md`](../actions/release-publish/README.md) — the
   composite that publishes the GitHub Release on tag push.
+- [`docs/workflow-trigger-conventions.md`](workflow-trigger-conventions.md) —
+  org-wide rules for `on:`, concurrency, and IRM paging.
 - [`docs/architecture.md`](architecture.md) — fleet architecture overview.

--- a/docs/workflow-trigger-conventions.md
+++ b/docs/workflow-trigger-conventions.md
@@ -1,0 +1,227 @@
+# Workflow trigger conventions
+
+Org-wide rules for how GitHub Actions workflows in `DevSecNinja/*` repos
+configure their `on:` triggers, `concurrency:` blocks, and Grafana IRM
+paging. The aim is to make every Actions run pull its weight — no
+duplicate executions, no silent skips, no runaway concurrent runs.
+
+## Why this exists
+
+A small flurry of commits to a PR can fire lint + test on the PR, then
+again on `push: main` after merge, and once more on release-please's
+response to that same push. Multiply by the set of checks branch
+protection requires and the noise drowns out signal — and burns Actions
+minutes for nothing.
+
+This doc lays down the rules. They're conservative defaults; deviate
+when a workflow genuinely needs more, but document the reason in the
+workflow file.
+
+---
+
+## Trigger surface
+
+**Default for CI workflows: `on: pull_request` only.**
+Branch protection guarantees the merge commit is identical to the last
+PR head that passed checks, so re-running the same lint/test on
+`push: main` immediately after merge is duplicate work.
+
+Keep `push: branches: [main]` **only** when the workflow has
+post-merge-only work to do:
+
+- **Documentation publishing** (e.g. `docs.yml` deploys mkdocs/Pages
+  from `main`).
+- **release-please** (`release-please.yml` must run on every commit to
+  `main` to keep the release PR up to date).
+- **Scheduled scans that also want a `main` snapshot** (e.g.
+  `image-security.yml` runs weekly and on push to `main` so the latest
+  shipped image set is always represented).
+- **Label / repo config workflows** where the PR run validates and the
+  `main` run applies (e.g. `label-sync.yml`).
+- **TODO-to-issue conversion** (`todo-to-issue.yml`) — only meaningful
+  on the integrated `main` history.
+
+**Avoid `pull_request_target`** unless absolutely required. It runs the
+target-branch workflow with write tokens against PR-author code, and
+mis-configuration is a well-known supply-chain footgun. If you must use
+it, restrict to specific event types (e.g. `[labeled]`) and never check
+out the PR head with the elevated token.
+
+---
+
+## Concurrency
+
+Always set workflow-level concurrency. The right shape depends on
+whether mid-run cancellation is safe.
+
+**For PR-validation CI (lint / test) — cancellable:**
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+This collapses redundant runs when a contributor pushes several commits
+in a row. The `pull_request.number || github.ref` fallback keeps groups
+distinct between PR runs and any `push` runs of the same workflow.
+
+**For release / docs-publish / release-please — NOT cancellable:**
+
+```yaml
+concurrency:
+  group: <stable-name>-${{ github.ref }}
+  cancel-in-progress: false
+```
+
+Mid-run cancellation can corrupt state: half-uploaded release assets,
+partially-deployed Pages builds, release-please's own retry-on-empty-PR
+logic interrupted mid-write. Let the run finish; queue the next one.
+
+**Reusable workflows (`on: workflow_call`) generally should not declare
+their own concurrency** — the caller owns it. A reusable that sets its
+own group can collide with the caller's group across repos and serialize
+unrelated runs.
+
+---
+
+## Draft PRs
+
+GitHub fires `pull_request` events on draft PRs by default. We do
+**not** add `if: github.event.pull_request.draft == false` guards.
+
+release-please opens its release PRs as draft on purpose
+(`draft-pull-request: true`) so contributors can spot them mid-cycle
+without merging by accident. If we skip CI on drafts, the
+required-status-checks list is never satisfied and the release PR can't
+merge — defeating the whole flow.
+
+If a particular workflow is genuinely too expensive to run on drafts
+(e.g. multi-hour image scans), gate that _job_ on a label
+(`if: contains(github.event.pull_request.labels.*.name, 'full-scan')`)
+rather than on draft state.
+
+---
+
+## Path filters
+
+We avoid `paths:` / `paths-ignore:` on workflows whose checks are
+**required by branch protection**. The interaction is fragile: a
+required check that's _skipped_ via path filter blocks merge until you
+add a no-op "skipped means success" job — more complexity than the
+filter saves.
+
+Path filters are fine on workflows that are **not** required to merge
+(scheduled scans, optional previews, advisory jobs).
+
+---
+
+## Notify Grafana IRM
+
+The `notify-irm` job pages the homelab on-call via the composite action
+at
+[`DevSecNinja/.github/.github/actions/notify-irm`](../actions/notify-irm/).
+Conventions:
+
+1. **Gate on `github.ref == 'refs/heads/main'` only.** Do _not_ also
+   gate on `github.event_name == 'push'` — that silently skips paging
+   on `workflow_dispatch` reruns, which is exactly when an operator is
+   most likely to need confirmation that the rerun succeeded or paged.
+   See
+   [DevSecNinja/dotfiles#265](https://github.com/DevSecNinja/dotfiles/pull/265)
+   and
+   [DevSecNinja/truenas-apps#317](https://github.com/DevSecNinja/truenas-apps/pull/317).
+2. **Don't add `notify-irm` to PR-only CI workflows** (lint, test,
+   `ci`). Without `push: main` it's unreachable, and pages on
+   PR-validation are low-value: failed PRs can't merge anyway, and the
+   author is already looking at the run.
+3. **Page on workflows that produce real artifacts or modify shared
+   state**: deploy, release publish, release-please, docs publish,
+   scheduled scans.
+4. Always shape the job like:
+
+   ```yaml
+   notify-irm:
+     needs: [<previous jobs>]
+     if: ${{ always() && github.ref == 'refs/heads/main' }}
+     uses: DevSecNinja/.github/.github/workflows/notify-irm.yml@<sha> # vX.Y.Z
+     with:
+       job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+   ```
+
+   `always()` is required so the job runs even when an upstream job
+   failed; the explicit `cancelled` check ensures cancellations also
+   page (otherwise a stuck deploy that an operator cancels looks like
+   a green run from IRM's point of view).
+
+---
+
+## Release flow with release-please
+
+release-please uses a draft-then-publish pattern with an opt-in
+`release-please.yml` per repo. The configuration that works reliably
+across the org:
+
+- `release-please-config.json`: `skip-github-release: false`,
+  `draft: true`, `force-tag-creation: true`, `draft-pull-request: true`.
+- After the release PR merges, release-please pushes the `vX.Y.Z` tag
+  and creates a _draft_ GitHub Release with the changelog body.
+- A separate caller workflow (e.g. `release.yml`) listens on
+  `push: tags: ["v*"]`, fetches the draft body via
+  `gh release view --json body --jq .body`, builds / uploads / attests
+  artifacts, then flips `--draft=false` to publish.
+
+**Trigger downstream release workflows on `push: tags`, NOT on
+`release: created`.** The `release: created` event from
+release-please's GitHub App token does not propagate reliably to
+workflows in the same repo — tag-push events do. See
+[DevSecNinja/dotfiles#263](https://github.com/DevSecNinja/dotfiles/pull/263)
+and
+[DevSecNinja/dotfiles#266](https://github.com/DevSecNinja/dotfiles/pull/266)
+for the diagnosis trail.
+
+The draft-publish pattern is also compatible with **Immutable
+Releases** — the API only constrains a Release once it's been
+published, so the draft can be edited freely up until the final flip.
+
+`workflow_dispatch` as a manual escape hatch is fine for one-offs
+(re-publish a botched release, etc.) but tightens immutability if
+removed once the tag-push path is proven.
+
+See
+[DevSecNinja/truenas-apps#325](https://github.com/DevSecNinja/truenas-apps/pull/325)
+for an end-to-end example caller.
+
+---
+
+## Conventional Commits gate
+
+The `commit-msg` lefthook (where used) verifies messages with
+`cog verify`. PRs that squash-merge should ensure the _squash title_
+also follows Conventional Commits — that's the line release-please
+parses. Use the GitHub merge-queue / "default to PR title" repo setting
+to make this automatic.
+
+---
+
+## Quick reference
+
+| Workflow type               | Triggers                                                    | Concurrency   | Notify IRM |
+| --------------------------- | ----------------------------------------------------------- | ------------- | ---------- |
+| Lint / test (PR-validation) | `pull_request`                                              | cancel=true   | no         |
+| Docs publish                | `push: main`, `pull_request` (preview-only)                 | cancel=false  | yes        |
+| release-please              | `push: main`, `workflow_dispatch`                           | cancel=false  | yes        |
+| Release publish             | `push: tags ["v*"]`                                         | cancel=false  | yes        |
+| Image security scan         | `schedule`, `workflow_dispatch`, `pull_request`             | cancel=false  | yes        |
+| Label sync                  | `push: main` (apply), `pull_request` (validate), `schedule` | cancel=false  | optional   |
+| TODO-to-issue               | `push: main`                                                | n/a           | optional   |
+| Reusable workflow           | `workflow_call`                                             | none (caller) | n/a        |
+
+---
+
+## Related docs
+
+- [`docs/release-please-onboarding.md`](release-please-onboarding.md) —
+  the release flow these conventions assume.
+- [`docs/architecture.md`](architecture.md) — fleet architecture
+  overview and reusable-workflow catalogue.


### PR DESCRIPTION
## Why

We've converged on a consistent set of GitHub Actions trigger / concurrency / IRM patterns across truenas-apps and dotfiles. Without a written reference each new repo (or each future me) re-derives them — and gets the subtle traps wrong (`event_name == 'push'` silently skipping `workflow_dispatch` reruns; `release: created` not firing reliably from GitHub App tokens; etc.).

## What

New page `docs/workflow-trigger-conventions.md` covering:

- Default trigger surface (`pull_request`-only for CI; when `push: main` is justified).
- Why we don't use `pull_request_target` casually.
- Concurrency: cancellable for PR-validation, non-cancellable for release/docs-publish; reusable workflows defer to caller.
- Why we don't gate on draft PRs (release-please opens drafts by design).
- Why we avoid path filters on required checks.
- `notify-irm` rules: gate on `github.ref == 'refs/heads/main'` only; **do not** also gate on `github.event_name == 'push'`; don't add to PR-only CI workflows.
- Release flow with release-please: draft-publish, tag-push trigger (NOT `release: created`), Immutable Releases compatibility.
- Quick-reference table for common workflow types.

Plus:

- `README.md`: new table row linking to the doc.
- `docs/release-please-onboarding.md`: cross-link in the release flow section.

## Motivating PRs

- DevSecNinja/dotfiles#263 — switch `release.yml` from `release: created` to `push: tags v*`
- DevSecNinja/dotfiles#265, DevSecNinja/truenas-apps#317 — drop `event_name == 'push'` gate from `notify-irm`
- DevSecNinja/truenas-apps#325, DevSecNinja/dotfiles#266 — drop redundant `push: main` from PR-validation workflows