### PR TITLE
Revert "fix(renovate): pin Renovate version ranges by default"

### DIFF
--- a/.renovate/base.json5
+++ b/.renovate/base.json5
@@ -6,7 +6,6 @@
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
   suppressNotifications: ["prEditedNotification", "prIgnoreNotification"],
   pinDigests: true,
-  rangeStrategy: "pin",
   labels: ["dependencies"],
   osvVulnerabilityAlerts: true,
   timezone: 'Europe/Amsterdam',


### PR DESCRIPTION
Reverts DevSecNinja/.github#70

Didn't have the intended effect. Now a lot of pin dependency issues were created that only updated the SHA hash.