### PR TITLE
feat(renovate): add digest-pinned container image custom manager

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -23,6 +23,24 @@
       datasourceTemplate: "{{{datasource}}}",
     },
     {
+      // Container images pinned by digest in GitHub Actions workflows. Annotate
+      // the image line with a Renovate comment, e.g.:
+      //   # renovate: datasource=docker depName=mcr.microsoft.com/devcontainers/base
+      //   source: "mcr.microsoft.com/devcontainers/base:debian-12@sha256:..."
+      // The key (source:, image:, etc.) is irrelevant; both the tag and the
+      // digest are kept up to date.
+      customType: "regex",
+      description: "Process digest-pinned container images in GitHub Actions workflows",
+      managerFilePatterns: [
+        "/.github/workflows/.+\\.ya?ml$/",
+        "/workflow-templates/.+\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s+[\\w-]+:\\s*\"?[^\\s\"@]+:(?<currentValue>[^\\s\"@]+)@(?<currentDigest>sha256:[a-f0-9]+)\"?",
+      ],
+      datasourceTemplate: "{{{datasource}}}",
+    },
+    {
       customType: "regex",
       description: "Process min_version in .mise.toml",
       managerFilePatterns: ["/\\.mise\\.toml$/"],


### PR DESCRIPTION
## Summary
Adds a reusable, comment-driven Renovate custom manager for **container images pinned by digest** in GitHub Actions workflows. Repos that extend `github>DevSecNinja/.github//.renovate/customManagers.json5` inherit it automatically, so they no longer need a repo-local manager to keep mirrored/pinned base images current.

## Convention
Annotate the image line with the standard `# renovate:` comment (matching the existing managers in this preset):

```yaml
# renovate: datasource=docker depName=mcr.microsoft.com/devcontainers/base
source: "mcr.microsoft.com/devcontainers/base:debian-12@sha256:23fa..."
```

- The key name is irrelevant (`source:`, `image:`, matrix entries, etc.).
- Both the **tag** (`currentValue`) and the **digest** (`currentDigest`) are kept up to date.
- `datasource`/`depName` come from the comment, consistent with the existing "Process tool versions in GitHub Actions workflows" manager.

## Motivation
`DevSecNinja/dotfiles` mirrors the devcontainer base image (MCR) into GHCR via a matrix workflow, with the upstream pin in a matrix `source:` field. The existing generic workflow manager only matches `version:` keys and does not capture a digest, so dotfiles currently carries a repo-local custom manager. This preset addition lets dotfiles (and any future repo) drop that local block and rely on the shared preset.

## Notes
- Purely additive — no existing manager is modified.
- The follow-up dotfiles PR will add the comment annotation and remove its local `customManagers` block.