### PR TITLE
fix(renovate): strip leading v from mise node version pins

### DIFF
--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -51,6 +51,12 @@
       pinDigests: false,
     },
     {
+      description: "The node-version datasource returns versions with a leading \"v\" (e.g. v24.17.0), but mise expects them without it (24.17.0). Strip the prefix so pinning .mise.toml produces valid versions.",
+      matchManagers: ["mise"],
+      matchDepNames: ["node"],
+      extractVersion: "^v?(?<version>.+)$",
+    },
+    {
       matchDatasources: ["github-releases"],
       minimumReleaseAge: "14 days",
     },


### PR DESCRIPTION
## Problem

The `pin dependencies` Renovate PR for `.mise.toml` produces an invalid value: it pins `node = "v24.17.0"` (with a leading `v`), which mise can't resolve. mise expects bare versions like `24.17.0`.

See: DevSecNinja/grip-visualizer#41

## Cause

The `node-version` datasource returns versions with a leading `v` prefix.

## Fix

Add a shared `packageRule` scoped to the `mise` manager + `node` dep that strips the prefix:

```json5
{
  matchManagers: ["mise"],
  matchDepNames: ["node"],
  extractVersion: "^v?(?<version>.+)$",
}
```

Doing this centrally means every repo consuming these presets gets the fix automatically.

## Follow-up

After this merges, existing `pin`/update PRs (e.g. grip-visualizer#41) should be rebased/regenerated so Renovate produces `24.17.0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>