### PR TITLE
ci(renovate): group the Vite ecosystem into a single PR

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -16,5 +16,16 @@
       ],
       minimumGroupSize: 2,
     },
+    {
+      // vite, @vitejs/* and vitest share vite as a (peer) dependency and
+      // their majors are interdependent — e.g. vite@8 requires
+      // @vitejs/plugin-react@6, which in turn drops support for vite<8.
+      // Updating them separately leaves package.json and the lockfile out
+      // of sync (Renovate "Artifact file update failure"), so group them
+      // into a single PR.
+      description: "Group the Vite ecosystem (vite, @vitejs/*, vitest)",
+      groupName: "vite",
+      matchPackageNames: ["vite", "@vitejs/**", "vitest", "@vitest/**"],
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Adds a **Vite ecosystem** group to the shared Renovate `groups.json5` preset, so `vite`, `@vitejs/*`, `vitest`, and `@vitest/*` are updated together in a single PR across all repos consuming this preset.

## Why

In `DevSecNinja/grip-visualizer` the separate vite (`6→8`) and `@vitejs/plugin-react` (`4→6`) PRs both failed with Renovate **"Artifact file update failure"** and then `npm ci` errors in CI. These packages are interdependent:

- `vite@8` requires `@vitejs/plugin-react@6`
- `@vitejs/plugin-react@4` peer-caps vite at `^7`

Updating them individually can't produce a consistent `package-lock.json`, so `package.json` and the lockfile drift apart. Grouping resolves the lockfile in one go.

## Change

```json5
{
  description: "Group the Vite ecosystem (vite, @vitejs/*, vitest)",
  groupName: "vite",
  matchPackageNames: ["vite", "@vitejs/**", "vitest", "@vitest/**"],
}
```

The same rule was added repo-locally in [grip-visualizer#58](https://github.com/DevSecNinja/grip-visualizer/pull/58); promoting it here lets every consumer benefit. Once this merges, the repo-local rule can be dropped.

🤖 Generated with Copilot CLI