### PR TITLE
ci(pages): fetch tags so builds can derive release metadata

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -219,6 +219,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Fetch tags so builds can read the release tag at HEAD
+          # (footer/version metadata). Safe when no tags exist.
+          fetch-tags: true
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -302,6 +305,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Fetch tags so builds can read the release tag at HEAD
+          # (footer/version metadata). Safe when no tags exist.
+          fetch-tags: true
 
       - name: Setup Node.js
         if: ${{ inputs.build-command != '' }}
@@ -379,6 +385,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Fetch tags so builds can read the release tag at HEAD
+          # (footer/version metadata). Safe when no tags exist.
+          fetch-tags: true
 
       - name: Setup Node.js
         if: ${{ inputs.build-command != '' }}


### PR DESCRIPTION
## Summary

The reusable Pages workflow checks out with `actions/checkout`'s default shallow fetch (`fetch-depth: 1`) and **does not fetch tags**. As a result, `build-command` steps cannot see git tags, so a consuming site cannot tell which release a build corresponds to — every `vite build` (production *and* PR preview) looks identical.

This adds `fetch-tags: true` to the three build job checkouts:

- `deploy` (GitHub Pages)
- `deploy-cloudflare-production`
- `deploy-preview`

## Why

A consumer ([DevSecNinja/grip-visualizer#60](https://github.com/DevSecNinja/grip-visualizer/pull/60)) wants to show a release-version link in the footer **only** when the deployed commit is an actual release. The clean signal is "is there a release tag pointing at `HEAD`?" (`git tag --points-at HEAD`). That requires tags to be present in the checkout.

With this change a build step can reliably:

- show release/version metadata on real release deploys (tag present at `HEAD`), and
- omit it on preview deploys and post-release `main` commits (no tag at `HEAD`).

## Notes

- `fetch-tags: true` keeps the shallow `fetch-depth: 1` (fast) but additionally fetches tag refs — harmless for repos without tags.
- The `test` job is intentionally left unchanged (it does not build/need tags).
- Validated locally with `actionlint` (clean) and `yamllint` (passes under the repo config). No behavioural change other than tag availability.