### PR TITLE
ci(lint): cache dprint plugins and pin plugin integrity checksum

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -126,6 +126,14 @@ jobs:
           install_args: "dprint"
           version: ${{ inputs.mise-version }}
 
+      - name: Cache dprint plugins
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/dprint
+          key: dprint-${{ runner.os }}-${{ hashFiles('**/dprint.json', '**/.dprint.json', '**/dprint.jsonc', '**/.dprint.jsonc') }}
+          restore-keys: |
+            dprint-${{ runner.os }}-
+
       - name: Check formatting with dprint
         env:
           CONFIG_DIR: ${{ inputs.lint-config-dir }}

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -70,5 +70,20 @@
       depNameTemplate: "DevSecNinja/dotfiles",
       datasourceTemplate: "github-releases",
     },
+    {
+      // Track dprint WASM plugin versions in dprint config files. The plugin
+      // URL is pinned with an integrity checksum (…wasm@<sha256>); Renovate can
+      // bump the version but cannot recompute the checksum, so a plugin update
+      // PR will fail the dprint check until the hash is refreshed with
+      // `dprint config update`. That red check is the intended signal.
+      customType: "regex",
+      description: "Update dprint WASM plugin versions in dprint config files",
+      managerFilePatterns: ["/(^|/)\\.?dprint\\.jsonc?$/"],
+      matchStrings: [
+        "https://plugins\\.dprint\\.dev/(?<depName>[a-z0-9-]+?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.wasm",
+      ],
+      depNameTemplate: "dprint/dprint-plugin-{{{depName}}}",
+      datasourceTemplate: "github-releases",
+    },
   ],
 }

--- a/config-sync/files/dprint.json
+++ b/config-sync/files/dprint.json
@@ -3,6 +3,6 @@
   "includes": ["**/*.md"],
   "excludes": ["**/node_modules", "**/CHANGELOG.md", "**/release-notes.md"],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.21.1.wasm"
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm@064467750514c9ce5192b375582d762ec64cb3ba99673413fa86645d50406279"
   ]
 }


### PR DESCRIPTION
> **Stacked on #179** (base = `ci/lint-dprint-reliability`). GitHub will auto-retarget this to
> `main` once #179 merges. Review/merge #179 first.

## Why

The reusable `lint.yml` `dprint` job intermittently hangs (2 min → up to the 6 h default)
because `dprint` downloads and compiles the `markdown` **WASM plugin from `plugins.dprint.dev`
on every run** and the plugin cache is never persisted. This PR adds the caching + integrity
piece, split out from #179 (which keeps the pure `install_args`/timeout hygiene).

## What changed

**`.github/workflows/lint.yml`** — cache `~/.cache/dprint` in the `dprint` job, keyed on the hash
of the repo's dprint config. The markdown WASM plugin is fetched + compiled **once** and reused,
removing the per-run network dependency that causes the hang.

**`config-sync/files/dprint.json`** (synced to all consumer repos) — pin the plugin with its
sha256 integrity checksum (`markdown-0.21.1.wasm@<sha256>`) so a tampered or swapped plugin is
rejected. Verified locally: correct hash → exit 0, wrong hash → exit 12.

**`.renovate/customManagers.json5`** — new custom manager tracks dprint plugin versions against
their GitHub releases (`dprint/dprint-plugin-<name>`), so version bumps still surface
automatically.

## ⚠️ Tradeoff (checksum + Renovate)

Renovate has **no native dprint manager** and **cannot recompute the WASM sha256**. So when the
custom manager opens a plugin-version bump, the `@<sha256>` becomes stale and the `dprint` check
on that PR **fails until the hash is refreshed** with `dprint config update`. That red check is
the intended signal. If fully hands-off plugin updates are preferred over integrity pinning, drop
the `@<sha256>` from `config-sync/files/dprint.json` — the cache alone still fixes the hang.

The new `actions/cache` action is SHA-pinned (`v5.0.5`) and kept current by the GitHub Actions
manager.

## Validation

`actionlint` ✅ · `yamllint` ✅ · dprint config parse ✅ · `customManagers.json5` JSON5 ✅ ·
regex extracts `markdown` → `dprint/dprint-plugin-markdown` @ `0.21.1` ✅. Committed through
lefthook hooks (no `--no-verify`).