### PR TITLE
feat(apm): add reusable APM sync workflow + onboarding

### DIFF
--- a/.github/workflows/apm-sync.yml
+++ b/.github/workflows/apm-sync.yml
@@ -1,0 +1,160 @@
+---
+name: Reusable — APM Sync
+
+# Refreshes installed APM (Agent Package Manager) primitives in the calling
+# repo and opens a PR when anything changed — the agentic-primitive equivalent
+# of the config-sync workflow (which only handles static config files).
+#
+# What it does on each run:
+#   1. Installs a pinned `apm` CLI.
+#   2. Runs `apm update --yes`, which re-resolves every dependency in apm.yml to
+#      its latest matching Git ref, rewrites apm.lock.yaml, and redeploys the
+#      compiled primitives into the harness directories (.github/, .claude/, …).
+#   3. Opens (or force-updates) a PR with the result, via the central
+#      actions/open-pr composite. Branch protection is fully respected — the bot
+#      opens a PR and a human (or auto-merge with required checks) merges it.
+#
+# Prerequisite: the calling repo must already depend on at least one APM package
+# (run `apm install <owner>/<repo>` once and commit apm.yml + apm.lock.yaml). If
+# apm.yml is absent the job is a no-op.
+#
+# Authentication: open-pr defaults to GITHUB_TOKEN. Pushes made with
+# GITHUB_TOKEN do NOT retrigger workflows on the opened PR (GitHub design), so
+# under branch protection required checks won't run automatically. Pass `app-id`
+# + `app-private-key` to open the PR via a GitHub App identity so required CI
+# fires — same pattern as the release-please reusable.
+#
+# See also: DevSecNinja/.github docs/apm-sync-onboarding.md
+
+on:
+  workflow_call:
+    inputs:
+      apm-version:
+        description: |
+          Version of the `apm` CLI to install (e.g. v0.13.0). Required — the
+          caller owns the version (see ADR 0001). Accepts `vX.Y.Z` or `X.Y.Z`.
+        required: true
+        type: string
+      packages:
+        description: |
+          Optional space-separated list of package names to update (e.g.
+          "DevSecNinja/ai-toolkit"). When empty, every dependency in apm.yml is
+          refreshed.
+        required: false
+        type: string
+        default: ""
+      target-branch:
+        description: "Base branch the PR targets (defaults to main)."
+        required: false
+        type: string
+        default: main
+      pr-branch:
+        description: "Working branch the sync PR is pushed to."
+        required: false
+        type: string
+        default: chore/apm-sync
+      app-id:
+        description: |
+          GitHub App ID used to open the PR so required CI fires on it. When
+          unset, falls back to GITHUB_TOKEN (PR opens but won't retrigger CI).
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app-private-key:
+        description: "PEM contents of the GitHub App private key, paired with app-id."
+        required: false
+    outputs:
+      changed:
+        description: "`true` when the sync produced changes and a PR was opened/updated."
+        value: ${{ jobs.apm-sync.outputs.changed }}
+      pr-url:
+        description: "URL of the PR that was opened or reused, if any."
+        value: ${{ jobs.apm-sync.outputs.pr-url }}
+
+permissions:
+  contents: read
+
+jobs:
+  apm-sync:
+    name: Sync APM primitives
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      changed: ${{ steps.open-pr.outputs.changed }}
+      pr-url: ${{ steps.open-pr.outputs.pr-url }}
+    steps:
+      - name: Harden runner
+        # renovate: datasource=github-tags depName=DevSecNinja/.github
+        uses: DevSecNinja/.github/actions/harden-runner@c1725a7573e1cb5277889d925901b477ee814352 # v1.7.0
+
+      - name: Generate App token
+        id: app-token
+        if: inputs.app-id != ''
+        # renovate: datasource=github-releases depName=actions/create-github-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout calling repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Check for apm.yml
+        id: precheck
+        run: |
+          if [ ! -f apm.yml ]; then
+            echo "::notice::No apm.yml in this repo; nothing to sync."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Install apm CLI
+        if: steps.precheck.outputs.skip != 'true'
+        env:
+          VERSION: ${{ inputs.apm-version }}
+          APM_INSTALL_DIR: ${{ runner.temp }}/apm/bin
+          APM_LIB_DIR: ${{ runner.temp }}/apm/lib/apm
+        run: |
+          set -euo pipefail
+          curl -sSL https://aka.ms/apm-unix | sh
+          echo "${APM_INSTALL_DIR}" >> "${GITHUB_PATH}"
+
+      - name: Refresh APM primitives
+        if: steps.precheck.outputs.skip != 'true'
+        env:
+          PACKAGES: ${{ inputs.packages }}
+        run: |
+          set -euo pipefail
+          apm --version
+          # shellcheck disable=SC2086 # PACKAGES is an intentional arg list.
+          apm update --yes ${PACKAGES}
+
+      - name: Open sync PR
+        id: open-pr
+        if: steps.precheck.outputs.skip != 'true'
+        # renovate: datasource=github-tags depName=DevSecNinja/.github
+        uses: DevSecNinja/.github/actions/open-pr@c1725a7573e1cb5277889d925901b477ee814352 # v1.7.0
+        with:
+          branch: ${{ inputs.pr-branch }}
+          base: ${{ inputs.target-branch }}
+          title: "chore: sync APM primitives"
+          commit-message: "chore: sync APM primitives from upstream packages"
+          labels: apm-sync
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
+          body: |
+            Automated PR — refreshed APM primitives via `apm update`.
+
+            Installed primitives were re-resolved to the latest matching refs of
+            the packages in `apm.yml` and redeployed into the harness
+            directories. Review the diff and merge to adopt.
+
+            Triggered by `${{ github.workflow }}` on `${{ github.ref_name }}`
+            at commit `${{ github.sha }}`.

--- a/.github/workflows/apm-sync.yml
+++ b/.github/workflows/apm-sync.yml
@@ -157,7 +157,7 @@ jobs:
           commit-message: "chore: sync APM primitives from upstream packages"
           labels: apm-sync
           github-token: ${{ steps.app-token.outputs.token || github.token }}
-          body: |
+          body: |-
             Automated PR — refreshed APM primitives via `apm update`.
 
             Installed primitives were re-resolved to the latest matching refs of

--- a/.github/workflows/apm-sync.yml
+++ b/.github/workflows/apm-sync.yml
@@ -102,6 +102,14 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout calling repository
+        # zizmor: ignore[artipacked]
+        # Persisted credentials are required: the `actions/open-pr` step below
+        # invokes `git push --force-with-lease`, which relies on the bearer
+        # token that `actions/checkout` writes into the remote URL. Setting
+        # `persist-credentials: false` here breaks PR creation without offering
+        # meaningful isolation — this job runs no untrusted code (it only
+        # installs the pinned apm CLI and runs `apm update` over the repo's own
+        # committed apm.yml/apm.lock.yaml).
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ repositories.
 | Design decisions (ADRs)      | [`docs/design-decisions/`](docs/design-decisions/README.md)                    |
 | Architecture & usage guide   | [`docs/architecture.md`](docs/architecture.md)                                 |
 | Release Please onboarding    | [`docs/release-please-onboarding.md`](docs/release-please-onboarding.md)       |
+| APM Sync onboarding          | [`docs/apm-sync-onboarding.md`](docs/apm-sync-onboarding.md)                   |
 | Workflow trigger conventions | [`docs/workflow-trigger-conventions.md`](docs/workflow-trigger-conventions.md) |
 
 ## Development

--- a/config-sync/files/.yamlfmt.yaml
+++ b/config-sync/files/.yamlfmt.yaml
@@ -14,3 +14,8 @@ formatter:
   retain_line_breaks_single: true
   scan_folded_as_literal: true
   trim_trailing_whitespace: true
+# APM-managed / generated files use the tool's own formatting — never hand-edited.
+exclude:
+  - apm.yml
+  - apm.lock.yaml
+  - apm_modules/**

--- a/config-sync/files/.yamllint.yaml
+++ b/config-sync/files/.yamllint.yaml
@@ -14,3 +14,9 @@ rules:
       - "true"
       - "false"
     check-keys: false
+
+# APM-managed / generated files use the tool's own formatting — never hand-edited.
+ignore: |-
+  apm.yml
+  apm.lock.yaml
+  apm_modules/

--- a/config-sync/files/dprint.json
+++ b/config-sync/files/dprint.json
@@ -1,7 +1,22 @@
 {
   "$schema": "https://dprint.dev/schemas/v0.json",
   "includes": ["**/*.md"],
-  "excludes": ["**/node_modules", "**/CHANGELOG.md", "**/release-notes.md"],
+  "excludes": [
+    "**/node_modules",
+    "**/CHANGELOG.md",
+    "**/release-notes.md",
+    "apm_modules/**",
+    ".github/prompts/**",
+    ".github/instructions/**",
+    ".github/chatmodes/**",
+    ".claude/**",
+    ".cursor/**",
+    ".opencode/**",
+    ".gemini/**",
+    ".windsurf/**",
+    ".kiro/**",
+    ".agents/**"
+  ],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.21.1.wasm"
   ]

--- a/docs/apm-sync-onboarding.md
+++ b/docs/apm-sync-onboarding.md
@@ -1,0 +1,133 @@
+# APM Sync — onboarding a repo
+
+Step-by-step guide for keeping a repo's installed
+[APM (Agent Package Manager)](https://microsoft.github.io/apm/) primitives —
+prompts, instructions, agents, hooks — up to date with their upstream packages,
+using the central [`apm-sync.yml`](../.github/workflows/apm-sync.yml) reusable
+workflow.
+
+The end state: a scheduled (or manually dispatched) job runs `apm update`, and
+when an upstream package (e.g. `DevSecNinja/ai-toolkit`) ships new primitives, it
+opens a `chore: sync APM primitives` PR you merge to adopt them. **Branch
+protection is respected end-to-end — no bypass actor needed.**
+
+This is the agentic-primitive counterpart to
+[config-sync](../.github/workflows/config-sync.yml): config-sync distributes
+static files (linters, editorconfig, renovate), APM-sync distributes installable
+agent primitives.
+
+---
+
+## Prerequisites
+
+- The repo already depends on at least one APM package. Run this once locally and
+  commit the result:
+
+  ```sh
+  apm install DevSecNinja/ai-toolkit --target copilot
+  git add apm.yml apm.lock.yaml .github/   # plus any other harness dirs APM wrote
+  git commit -m "feat: install ai-toolkit APM primitives"
+  ```
+
+  > `apm_modules/` is the package cache — APM adds it to `.gitignore` on first
+  > install. Don't commit it.
+
+- (Recommended) The same `RELEASE_PLEASE_APP_ID` variable +
+  `RELEASE_PLEASE_APP_PRIVATE_KEY` secret used for release-please, so the sync PR
+  is opened by the App identity and required CI checks fire on it. Without the
+  App, the PR still opens via `GITHUB_TOKEN` but won't retrigger CI.
+
+---
+
+## Per-repo adoption
+
+Add a thin caller workflow. Pin `apm-version` to a real `apm` CLI release tag
+(the caller owns the version — see
+[ADR 0001](design-decisions/0001-reusable-workflow-version-inputs.md)).
+
+### `.github/workflows/apm-sync.yml`
+
+```yaml
+---
+name: APM Sync
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: apm-sync
+  cancel-in-progress: false
+jobs:
+  apm-sync:
+    # renovate: datasource=github-tags depName=DevSecNinja/.github
+    uses: DevSecNinja/.github/.github/workflows/apm-sync.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      # renovate: datasource=github-releases depName=microsoft/apm
+      apm-version: v0.13.0
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+```
+
+Pin `<sha>` to a release-tagged commit of `DevSecNinja/.github`; the `# renovate:`
+comments let Renovate bump both the reusable and the `apm` CLI version.
+
+### Optional inputs
+
+| Input           | Default          | Purpose                                                        |
+| --------------- | ---------------- | -------------------------------------------------------------- |
+| `apm-version`   | _(required)_     | `apm` CLI release to install.                                  |
+| `packages`      | _(all)_          | Space-separated package names to update; empty refreshes all.  |
+| `target-branch` | `main`           | Base branch the PR targets.                                    |
+| `pr-branch`     | `chore/apm-sync` | Working branch for the sync PR.                                |
+| `app-id`        | _(empty)_        | GitHub App ID so the PR triggers required CI.                  |
+
+---
+
+## What a run does
+
+1. Installs the pinned `apm` CLI.
+2. Runs `apm update --yes` (optionally scoped to `packages`), which re-resolves
+   every dependency in `apm.yml` to its latest matching ref, rewrites
+   `apm.lock.yaml`, and redeploys the compiled primitives into the harness
+   directories.
+3. If anything changed, opens (or force-updates) `chore: sync APM primitives`.
+4. You review and merge. Nothing is auto-merged.
+
+When there are no upstream changes, the job ends quietly with no PR.
+
+---
+
+## Troubleshooting
+
+### The sync PR opens but no CI runs on it
+
+The PR was opened with `GITHUB_TOKEN` instead of the App — `app-id` was empty.
+Set `RELEASE_PLEASE_APP_ID` (variable) + `RELEASE_PLEASE_APP_PRIVATE_KEY`
+(secret) and pass `app-id` as shown above. Quick unblock for an already-open PR:
+a human closes and reopens it.
+
+### `No apm.yml in this repo; nothing to sync`
+
+The repo hasn't installed any APM package yet. Do the one-time
+`apm install <pkg>` in the prerequisites and commit `apm.yml` + `apm.lock.yaml`.
+
+### Nothing happens / no PR
+
+`apm update` found no newer refs. Run `apm outdated` locally to confirm, or pin a
+new ref in `apm.yml`. Install never silently bumps — the workflow only adopts
+what `apm update` resolves.
+
+---
+
+## Related docs
+
+- [`.github/workflows/apm-sync.yml`](../.github/workflows/apm-sync.yml) — the reusable.
+- [`.github/workflows/config-sync.yml`](../.github/workflows/config-sync.yml) — static-file sync sibling.
+- [Release Please onboarding](release-please-onboarding.md) — shares the App auth setup.
+- [APM consumer docs](https://microsoft.github.io/apm/consumer/) — `install`, `update`, `outdated`.

--- a/docs/apm-sync-onboarding.md
+++ b/docs/apm-sync-onboarding.md
@@ -79,13 +79,13 @@ comments let Renovate bump both the reusable and the `apm` CLI version.
 
 ### Optional inputs
 
-| Input           | Default          | Purpose                                                        |
-| --------------- | ---------------- | -------------------------------------------------------------- |
-| `apm-version`   | _(required)_     | `apm` CLI release to install.                                  |
-| `packages`      | _(all)_          | Space-separated package names to update; empty refreshes all.  |
-| `target-branch` | `main`           | Base branch the PR targets.                                    |
-| `pr-branch`     | `chore/apm-sync` | Working branch for the sync PR.                                |
-| `app-id`        | _(empty)_        | GitHub App ID so the PR triggers required CI.                  |
+| Input           | Default          | Purpose                                                       |
+| --------------- | ---------------- | ------------------------------------------------------------- |
+| `apm-version`   | _(required)_     | `apm` CLI release to install.                                 |
+| `packages`      | _(all)_          | Space-separated package names to update; empty refreshes all. |
+| `target-branch` | `main`           | Base branch the PR targets.                                   |
+| `pr-branch`     | `chore/apm-sync` | Working branch for the sync PR.                               |
+| `app-id`        | _(empty)_        | GitHub App ID so the PR triggers required CI.                 |
 
 ---
 


### PR DESCRIPTION
## What

Adds a central **`apm-sync` reusable workflow** so any DevSecNinja repo can keep its installed [APM](https://microsoft.github.io/apm/) primitives (prompts, instructions, agents, hooks) up to date with their upstream packages — the agentic-primitive counterpart to `config-sync` (which only distributes static files).

- `.github/workflows/apm-sync.yml` — reusable (`workflow_call`).
- `docs/apm-sync-onboarding.md` — adoption guide (mirrors `release-please-onboarding.md`), linked from README.

## How it works

On each run (scheduled or `workflow_dispatch` in the caller):
1. Installs a **pinned** `apm` CLI (`curl -sSL https://aka.ms/apm-unix | sh`, `VERSION` pinned).
2. Runs `apm update --yes` — re-resolves every dep in `apm.yml` to its latest matching ref, rewrites `apm.lock.yaml`, and redeploys compiled primitives into the harness dirs (`.github/`, `.claude/`, …).
3. Opens/force-updates a `chore: sync APM primitives` PR via the existing `actions/open-pr` composite. **Branch protection respected — nothing auto-merges.**
4. No-op when the caller has no `apm.yml`.

## Conventions followed

- `apm-version` is **`required: true`** — caller owns the version (ADR 0001). `# renovate:` comments on both the reusable ref and the `apm` version.
- Optional `app-id` + `app-private-key` open the PR via the GitHub App so required CI fires on it — same pattern/secrets as the release-please reusable (`RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`); falls back to `GITHUB_TOKEN`.
- `harden-runner` (audit egress), pinned action SHAs, least-privilege `permissions`.

## The bigger picture

This pairs with [ai-toolkit#21](https://github.com/DevSecNinja/ai-toolkit/pull/21), which ships the org conventions as an APM **instruction** primitive. Once both merge, a repo runs `apm install DevSecNinja/ai-toolkit --target copilot` once, and this workflow keeps it current automatically — replacing the closed config-sync approach (`#193`) for *agentic* content while config-sync keeps owning static config.

## Validation note

I authored this via API and can't run actionlint/CI from here. The workflow follows the repo's existing reusable conventions; please let the lint workflow run on the PR. One thing worth a reviewer's eye: the exact `apm update` redeploy semantics in a headless CI checkout (e.g. whether a repo with zero harness dirs needs `targets:` in `apm.yml`) — the onboarding doc tells consumers to pin `--target` at install time, which covers the common case.