### PR TITLE
feat(apm): activate apm-sync on the .github consumer

### DIFF
--- a/.github/workflows/apm-sync-caller.yml
+++ b/.github/workflows/apm-sync-caller.yml
@@ -33,7 +33,9 @@ jobs:
       contents: write
       pull-requests: write
     with:
-      # renovate: datasource=pypi depName=apm-cli
+      # The reusable installs the apm CLI from the official aka.ms installer,
+      # which pulls the microsoft/apm GitHub release.
+      # renovate: datasource=github-releases depName=microsoft/apm
       apm-version: "0.21.0"
       app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
     secrets:

--- a/.github/workflows/apm-sync-caller.yml
+++ b/.github/workflows/apm-sync-caller.yml
@@ -1,0 +1,40 @@
+---
+name: APM Sync
+
+# Keeps this repo's installed APM primitives (from DevSecNinja/ai-toolkit,
+# declared in apm.yml) up to date via the central reusable workflow. On a
+# weekly schedule (or manual dispatch) it runs `apm update` and opens a
+# `chore: sync APM primitives` PR when an upstream package shipped changes.
+#
+# This is the agentic-primitive counterpart to config-sync. Branch protection
+# is respected end-to-end — the PR is opened by the App so required CI fires.
+#
+# Onboarding guide:
+#   docs/apm-sync-onboarding.md
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apm-sync
+  cancel-in-progress: false
+
+jobs:
+  apm-sync:
+    # Self-reference: same repo, pinned to the v1.8.0 tag SHA that introduced
+    # the apm-sync reusable. Re-pin to the next vX.Y.Z tag once cut.
+    uses: DevSecNinja/.github/.github/workflows/apm-sync.yml@7f2abdd838a855dba31a2b2de6358529fdcef09d # v1.8.0
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      # renovate: datasource=pypi depName=apm-cli
+      apm-version: "0.21.0"
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

**Activates the apm-sync flow** by wiring this repo (the first real APM consumer) into the central `apm-sync` reusable shipped in [v1.8.0](https://github.com/DevSecNinja/.github/releases/tag/v1.8.0) (#194/#188).

`.github` already `apm install`ed `DevSecNinja/ai-toolkit` (pinned `#v0.1.1` in `apm.yml`), but ai-toolkit has since shipped `v0.2.0`+ (skill, MCP servers, agent). This caller runs `apm update` weekly (or on dispatch) and opens a `chore: sync APM primitives` PR when upstream changed.

## Details

- Self-reference pinned to the `v1.8.0` tag SHA, with `# v1.8.0` comment + re-pin note — matching the `release-please-caller.yml` convention in this repo.
- Uses the App identity (`RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`) so the sync PR triggers required CI — same secrets as release-please.
- `apm-version` pinned + Renovate-tracked via `microsoft/apm` GitHub releases (the reusable installs the CLI from the official `aka.ms` installer).
- Weekly schedule + `workflow_dispatch` for on-demand runs.

## How to verify

After merge, trigger **Actions → APM Sync → Run workflow**. Expected: it installs `apm`, runs `apm update`, and (because the pinned `#v0.1.1` is behind `v0.2.0`) opens a PR bumping `apm.yml`/`apm.lock.yaml` and redeploying the refreshed primitives into `.github/`.

> Note: the APM-deployed files were already excluded from the linters in #194's follow-up, so the resulting sync PR won't trip yamllint/dprint.

## Follow-up

Other consumer repos can adopt the same caller via [`docs/apm-sync-onboarding.md`](https://github.com/DevSecNinja/.github/blob/main/docs/apm-sync-onboarding.md) (they'd use the external pinned form rather than this self-reference).