### PR TITLE
fix(ci): resolve zizmor template-injection, artipacked, and cache-poisoning alerts

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -43,6 +43,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
+        # zizmor: ignore[artipacked]
+        # Persisted credentials are required: the final step commits the
+        # auto-formatted changes and `git push`es them back to the branch using
+        # the token checkout writes into the remote URL. Setting
+        # `persist-credentials: false` here breaks that push without offering
+        # meaningful isolation — this job runs no untrusted code (it only runs
+        # the pinned formatters dprint/yamlfmt/shfmt over the repo's own files).
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install mise

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -279,8 +279,10 @@ jobs:
 
       - name: Validate golangci-lint version
         if: ${{ steps.go-version-file.outputs.exists == 'true' && inputs.golangci-lint-version == '' }}
+        env:
+          GO_VERSION_FILE: ${{ inputs.go-version-file }}
         run: |-
-          echo "::error::Go linting is required (${{ inputs.go-version-file }} found) but no golangci-lint-version input was provided. Pass golangci-lint-version when calling this reusable workflow for Go repositories."
+          echo "::error::Go linting is required (${GO_VERSION_FILE} found) but no golangci-lint-version input was provided. Pass golangci-lint-version when calling this reusable workflow for Go repositories."
           exit 1
 
       - name: Setup Go

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -235,7 +235,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.node-cache }}
+          # Caching disabled on this privileged production-deploy job to remove
+          # the cache-poisoning surface (zizmor), matching deploy-preview below.
+          # These jobs run only on merge to the production branch, so the lost
+          # package-download caching is negligible; test/preview keep it.
+          package-manager-cache: false
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}
@@ -322,7 +326,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.node-cache }}
+          # Caching disabled on this privileged production-deploy job to remove
+          # the cache-poisoning surface (zizmor), matching deploy-preview below.
+          # These jobs run only on merge to the production branch, so the lost
+          # package-download caching is negligible; test/preview keep it.
+          package-manager-cache: false
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}


### PR DESCRIPTION
Resolves **all three** open zizmor code-scanning alerts in the reusable workflows. None were introduced by recent APM work — all predate it.

## #21 — template-injection (high), `lint.yml`

The "Validate golangci-lint version" step interpolated `${{ inputs.go-version-file }}` straight into a `run:` script. Moved it into a `GO_VERSION_FILE` env var, matching the adjacent "Check for Go version file" step.

## #20 — artipacked (warning), `autofix.yml`

Checkout persists credentials, but the job's final step commits the auto-formatting fixes and `git push`es them — so the creds are required. Added a justified `# zizmor: ignore[artipacked]` suppression (mirrors `config-sync.yml`).

## #13 — cache-poisoning (high), `pages.yml`

Set **`package-manager-cache: false`** on the two privileged production-deploy jobs (GitHub Pages + Cloudflare production), matching the mitigation `deploy-preview` already uses. Those jobs run only on merge to the production branch, where setup-node's package-download cache saves seconds at most — so disabling it is near-free. The frequent `test` job keeps caching (read-only, not a publishing context, so not part of the poisoning surface).

**Analysis behind the decision:** real exploitability was already low (the only PR-triggered cache-writer is restricted to same-repo PRs — forks excluded — and GitHub scopes caches per-branch so a PR cache isn't restored on `main`). But the fix is essentially free and clears the alert, so we took it as defense-in-depth.

## Verification

`zizmor` → **No findings** on all three files. actionlint / yamllint / yamlfmt pass on each.