### PR TITLE
feat(labels): add apm-sync base label for materialize PRs

### DIFF
--- a/.github/labels-base.yaml
+++ b/.github/labels-base.yaml
@@ -46,6 +46,9 @@
   description: Release Please — release tagged
 - name: config-sync
   color: "0075ca"
+- name: apm-sync
+  color: "0075ca"
+  description: Automated APM materialize PR
 - name: todo-to-issue
   color: "0075ca"
 


### PR DESCRIPTION
## Problem
The pm-materialize workflow opens its PR with the `apm-sync` label (via the `open-pr` composite). That label isn't part of the org base label set, so consuming repos — e.g. [DevSecNinja/ai-toolkit](https://github.com/DevSecNinja/ai-toolkit/actions/runs/28024372446/job/82948347715) — fail the PR step with `label not found`.

## Change
Add `apm-sync` to `.github/labels-base.yaml` under the **Automation** group, next to `config-sync` (its static-file sibling), so `label-sync` provisions it across all repos.

```yaml
- name: apm-sync
  color: \"0075ca\"
  description: Automated APM materialize PR
```