### PR TITLE
feat(pages): make node-version and wrangler-version optional

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,18 +5,26 @@ on:
   workflow_call:
     inputs:
       node-version:
-        description: "Node.js version to install for test and build commands"
-        required: true
+        description: >-
+          Node.js version for setup-node. Required when install-command,
+          test-setup-command, test-command, or build-command is set; leave
+          empty for no-build static sites.
+        required: false
         type: string
+        default: ""
       node-cache:
         description: "Package manager cache for setup-node; use empty to disable"
         required: false
         type: string
         default: ""
       wrangler-version:
-        description: "Wrangler version to install for Cloudflare Pages previews"
-        required: true
+        description: >-
+          Wrangler version for Cloudflare Pages deploys. Required when
+          cloudflare-preview, cloudflare-production, or cloudflare-acceptance
+          is enabled.
+        required: false
         type: string
+        default: ""
       production-branch:
         description: "Branch that deploys to production"
         required: false
@@ -125,8 +133,50 @@ permissions:
   contents: read
 
 jobs:
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Validate tool versions
+        env:
+          NODE_VERSION: ${{ inputs.node-version }}
+          WRANGLER_VERSION: ${{ inputs.wrangler-version }}
+          INSTALL_COMMAND: ${{ inputs.install-command }}
+          TEST_SETUP_COMMAND: ${{ inputs.test-setup-command }}
+          TEST_COMMAND: ${{ inputs.test-command }}
+          BUILD_COMMAND: ${{ inputs.build-command }}
+          CLOUDFLARE_PREVIEW: ${{ inputs.cloudflare-preview }}
+          CLOUDFLARE_PRODUCTION: ${{ inputs.cloudflare-production }}
+          CLOUDFLARE_ACCEPTANCE: ${{ inputs.cloudflare-acceptance }}
+        run: |-
+          set -euo pipefail
+
+          if [ -z "${NODE_VERSION}" ] && {
+            [ -n "${INSTALL_COMMAND}" ] ||
+            [ -n "${TEST_SETUP_COMMAND}" ] ||
+            [ -n "${TEST_COMMAND}" ] ||
+            [ -n "${BUILD_COMMAND}" ]
+          }; then
+            echo "::error::node-version is required when install-command, test-setup-command, test-command, or build-command is set; provide node-version or clear those commands."
+            exit 1
+          fi
+
+          if [ -z "${WRANGLER_VERSION}" ] && {
+            [ "${CLOUDFLARE_PREVIEW}" = "true" ] ||
+            [ "${CLOUDFLARE_PRODUCTION}" = "true" ] ||
+            [ "${CLOUDFLARE_ACCEPTANCE}" = "true" ]
+          }; then
+            echo "::error::wrangler-version is required when cloudflare-preview, cloudflare-production, or cloudflare-acceptance is enabled."
+            exit 1
+          fi
+
+          echo "Input validation passed."
+
   detect-cloudflare:
     name: Detect Cloudflare configuration
+    needs:
+      - validate-inputs
     runs-on: ubuntu-24.04
     outputs:
       enabled: ${{ steps.detect.outputs.enabled }}
@@ -227,6 +277,8 @@ jobs:
 
   test:
     name: Run tests
+    needs:
+      - validate-inputs
     if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -237,6 +289,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
+        if: ${{ inputs.node-version != '' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
## Summary

`node-version` and `wrangler-version` were declared `required: true` on the reusable Pages workflow, forcing no-build static-site callers (e.g. a plain `index.html` repo) to pass values they never use.

This makes both inputs `required: false` **without defaulting the version** — callers still own the version, honoring the org rule that reusable workflows must not default package/tool versions. Instead, a new upfront `validate-inputs` job fails loudly with a clear message only when a step genuinely needs the tool:

- `node-version` is required when `install-command`, `test-setup-command`, `test-command`, or `build-command` is set.
- `wrangler-version` is required when `cloudflare-preview`, `cloudflare-production`, or `cloudflare-acceptance` is enabled.

## Changes

- `node-version` / `wrangler-version`: `required: false`, `default: ""`, updated descriptions.
- New `validate-inputs` job; `test` and `detect-cloudflare` now `needs: [validate-inputs]` so failures short-circuit the whole run.
- Test-job `Setup Node.js` now guarded on `inputs.node-version != ''`, so fully static sites skip Node setup entirely.

## Compatibility

Non-breaking: existing callers that pass both versions continue to work unchanged. New static-site callers can now omit both.

## Validation

YAML parses; the validation bash was unit-tested against representative input combinations (static site → pass; build set without node → fail; build set with node → pass; cloudflare enabled without wrangler → fail).