### PR TITLE
feat(pages)!: require artifact-path input

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,9 +37,8 @@ on:
         default: true
       artifact-path:
         description: "Path uploaded to GitHub Pages or Cloudflare Pages"
-        required: false
+        required: true
         type: string
-        default: "."
       install-command:
         description: "Dependency installation command"
         required: false


### PR DESCRIPTION
## Summary

`artifact-path` defaulted to `"."`, so a caller that doesn't set it silently publishes the **entire repo root** to GitHub Pages / Cloudflare — including `README.md`, config files, lockfiles, and other repo internals. This makes `artifact-path` `required: true` (no default) so every caller declares exactly what to publish.

## Changes

- `artifact-path`: `required: false` + `default: "."` → `required: true` (default removed). Description unchanged.

## Breaking change

This is a **breaking change** to the reusable workflow: existing callers that relied on the `"."` default must now pass `artifact-path` explicitly. Marked with `feat(pages)!` + a `BREAKING CHANGE:` footer so release-please bumps the major version and Renovate won't automerge the bump for downstream consumers.

Migration for callers:

```yaml
with:
  artifact-path: "public"   # or "." to keep previous whole-root behavior
```

The `DevSecNinja/edu-auth` consumer is already updated to pass `artifact-path: "public"`, so it's ready for this once it bumps the pin.

## Validation

YAML parses; the change was diff-verified byte-identical against the current `main` file with only the `artifact-path` block modified.