### PR TITLE
chore(devcontainer): pin dotfiles-devcontainer to v0.6.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "image": "ghcr.io/devsecninja/dotfiles-devcontainer:latest@sha256:f1f763aed2fde830531640c335341be23f87acc5b5ad621786c3962427258aa9",
+  "image": "ghcr.io/devsecninja/dotfiles-devcontainer:v0.6.0@sha256:238aec66927da1d67f7f7225123c1d207f7c01c93d451fab7189c94d53453940",
   "features": {},
   "postCreateCommand": "mise trust --all --yes && mise install",
   "remoteUser": "vscode",


### PR DESCRIPTION
Pin the prebuilt dotfiles devcontainer image to the released tag `v0.6.0` (digest `sha256:238aec66927da1d67f7f7225123c1d207f7c01c93d451fab7189c94d53453940`) instead of tracking a moving `latest` digest, to stop frequent digest churn. Renovate will now propose reviewable version bumps (auto-merged for patch/minor per the shared preset).