### PR TITLE
feat(lint): add upload-sarif input to skip GitHub code scanning upload

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,6 +98,13 @@ on:
         required: false
         type: boolean
         default: false
+      upload-sarif:
+        description: "Upload checkov/trivy/zizmor results to GitHub code scanning (requires GitHub
+          Advanced Security). Set false for private repos without GHAS to gate on exit codes with
+          console output instead."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -452,10 +459,18 @@ jobs:
           version: ${{ inputs.mise-version }}
 
       - name: Run checkov
-        run: mise exec -- checkov -d . --output sarif --output-file-path . || true
+        env:
+          UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+        run: |-
+          if [ "${UPLOAD_SARIF}" = "true" ]; then
+            mise exec -- checkov -d . --output sarif --output-file-path . || true
+          else
+            # No GitHub Advanced Security: gate on exit code with console output.
+            mise exec -- checkov -d . --compact --quiet
+          fi
 
       - name: Filter skipped checks from SARIF
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         run: |-
           if [ -f results_sarif.sarif ]; then
             jq '
@@ -470,7 +485,7 @@ jobs:
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         with:
           sarif_file: results_sarif.sarif
           category: checkov
@@ -499,6 +514,7 @@ jobs:
       - name: Run trivy
         env:
           CONFIG_DIR: ${{ inputs.lint-config-dir }}
+          UPLOAD_SARIF: ${{ inputs.upload-sarif }}
         run: |-
           # Lint tool versions are owned by the consuming repo: pinned and
           # Renovate-managed in its mise config. Fail early with guidance when
@@ -516,13 +532,21 @@ jobs:
             trivy_args+=(--config "${CONFIG_DIR}/trivy.yaml")
           fi
 
-          mise exec -- trivy fs "${trivy_args[@]}" \
-            --scanners misconfig,secret \
-            --format sarif \
-            --output trivy.sarif . || true
+          if [ "${UPLOAD_SARIF}" = "true" ]; then
+            mise exec -- trivy fs "${trivy_args[@]}" \
+              --scanners misconfig,secret \
+              --format sarif \
+              --output trivy.sarif . || true
+          else
+            # No GitHub Advanced Security: gate on exit code with console output.
+            mise exec -- trivy fs "${trivy_args[@]}" \
+              --scanners misconfig,secret \
+              --exit-code 1 .
+          fi
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        if: ${{ inputs.upload-sarif }}
         with:
           sarif_file: trivy.sarif
           category: trivy
@@ -549,11 +573,19 @@ jobs:
           version: ${{ inputs.mise-version }}
 
       - name: Run zizmor
-        run: mise exec -- zizmor --format sarif . > zizmor.sarif
+        env:
+          UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+        run: |-
+          if [ "${UPLOAD_SARIF}" = "true" ]; then
+            mise exec -- zizmor --format sarif . > zizmor.sarif
+          else
+            # No GitHub Advanced Security: gate on exit code with console output.
+            mise exec -- zizmor .
+          fi
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         with:
           sarif_file: zizmor.sarif
           category: zizmor

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,9 +99,8 @@ on:
         type: boolean
         default: false
       upload-sarif:
-        description: "Upload checkov/trivy/zizmor results to GitHub code scanning (requires GitHub
-          Advanced Security). Set false for private repos without GHAS to gate on exit codes with
-          console output instead."
+        description: "Upload checkov/trivy/zizmor results to GitHub code scanning (requires GitHub Advanced Security). Set
+          false for private repos without GHAS to gate on exit codes with console output instead."
         required: false
         type: boolean
         default: true

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -25,6 +25,10 @@ jobs:
       # lint-config-dir: config-sync/files
       # Optional: fail this workflow when a linter fails (default: false).
       # lint-fail-on-error: true
+      # Optional: upload checkov/trivy/zizmor results to GitHub code scanning
+      # (default: true, requires GitHub Advanced Security). Set false for
+      # private repos without GHAS to gate on exit codes with console output.
+      # upload-sarif: false
       # Optional: use a different Go version file.
       # go-version-file: go.mod
       # Toggle linters on/off (all default to true):


### PR DESCRIPTION
## Problem

The reusable `lint.yml` workflow's `checkov`, `trivy`, and `zizmor` jobs always upload their results via `github/codeql-action/upload-sarif`, which requires **GitHub Advanced Security** (code scanning). On **private repos without GHAS**, the upload step fails with:

```
Error: Resource not accessible by integration
```

…which fails the whole lint job — even when the scanners themselves found nothing. There was no way to opt out of the SARIF upload, so these three security scanners were effectively unusable on private repos without a GHAS license.

## Solution

Add a new `upload-sarif` input (boolean, **default `true`** — fully backward-compatible):

- **`true`** (default): unchanged behavior — scanners emit SARIF and upload to GitHub code scanning.
- **`false`**: the `checkov`/`trivy`/`zizmor` jobs run with **console output and gate on their exit codes** instead of uploading SARIF. Findings still block the build (when `lint-fail-on-error: true`); results appear in the job logs instead of the Security tab.

Each job branches internally on the input (single run step), and the `Upload SARIF report` steps are guarded with `if: ${{ ... && inputs.upload-sarif }}`.

## Notes

- Callers still grant `security-events: write` (job permissions are static and can't be conditional), but no upload — and therefore no GHAS — is required when `upload-sarif: false`.
- `workflow-templates/lint.yml` documents the new input.
- Validated locally: `actionlint`, `yamllint` (central config), and `zizmor` all pass on the edited workflow.

## Motivation

Unblocks the private `DevSecNinja/second-brain` repo (no GHAS) from adopting the org-standard security lint (see DevSecNinja/second-brain#11).