### PR TITLE
fix(renovate): set internalChecksFilter to strict

### DIFF
--- a/.renovate/base.json5
+++ b/.renovate/base.json5
@@ -8,6 +8,13 @@
   pinDigests: true,
   rangeStrategy: "pin",
   minimumReleaseAge: "14 days",
+  // Skip versions still inside their minimumReleaseAge soak and propose the
+  // highest already-soaked version instead of parking the update on the newest
+  // (still-pending) release. Without this, frequently-releasing dependencies
+  // stay stuck under the dependency dashboard's "Pending Status Checks" section
+  // and their PRs are never created (their renovate/stability-days check never
+  // clears). See DevSecNinja/truenas-apps#115.
+  internalChecksFilter: "strict",
   labels: ["dependencies"],
   osvVulnerabilityAlerts: true,
   timezone: 'Europe/Amsterdam',


### PR DESCRIPTION
## Problem

Repositories consuming these shared Renovate presets get container/tool updates stuck under the dependency dashboard's **"Pending Status Checks"** section, and their PRs are never created. Reported in DevSecNinja/truenas-apps#115 (e.g. `ghcr.io/italypaleale/traefik-forward-auth` stuck at `4.8.0` since March while `4.9`–`4.13` shipped).

## Root cause

`base.json5` sets `minimumReleaseAge: "14 days"` but leaves `internalChecksFilter` at its effective `none` behaviour. Renovate keeps targeting the **newest** release — which is still inside its 14-day soak — so the internal `renovate/stability-days` check stays pending forever for frequently-releasing dependencies, and no branch/PR is created.

Verified on a stuck `socket-proxy` branch: all required CI checks passed; only `renovate/stability-days` (_"Updates have not met minimum release age requirement"_) was pending, and the branch sat orphaned for 3+ months.

## Fix

Add `internalChecksFilter: "strict"` next to `minimumReleaseAge` so Renovate skips still-pending versions and proposes the highest **already-soaked** version. The soaked update then creates a PR and auto-merges, while the 14-day supply-chain soak is preserved. Applies to every repo extending `base.json5`.

Refs DevSecNinja/truenas-apps#115