### PR TITLE
fix(renovate): drop invalid minimumReleaseAge override on automerge rule

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -13,7 +13,6 @@
       platformAutomerge: true,
       commitMessageSuffix: "[automerge]",
       addLabels: ["merge: auto"],
-      minimumReleaseAge: "null",
     },
   ],
 }


### PR DESCRIPTION
## Problem

The automerge `packageRule` in `.renovate/autoMerge.json5` sets:

```json5
minimumReleaseAge: "null",
```

This is the **string** `"null"`, not JSON `null`. It is not a valid duration, so Renovate silently ignores it. Worse, even if it were real `null` it would *waive* the soak — directly contradicting the rule's own comment:

> Risk is covered by the global minimumReleaseAge soak time in base.json5 plus required status checks

…and the intent of ADR 0004 (auto-merge non-major updates **only after** the soak).

## Fix

Remove the line so automerge updates inherit the global `minimumReleaseAge: "14 days"` from `base.json5`, as the comment and ADR intend.

No behaviour change for container images — `packageRules.json5`'s docker rule already enforces `14 days` and is applied later. This just removes dead/misleading config and fixes the latent bug.

Follow-up to #284. Refs DevSecNinja/truenas-apps#115