### PR TITLE
feat(renovate): PR-age cooldown for registries without trusted timestamps

### DIFF
--- a/.github/workflows/renovate-pr-cooldown-caller.yml
+++ b/.github/workflows/renovate-pr-cooldown-caller.yml
@@ -1,0 +1,20 @@
+---
+name: Renovate PR cooldown
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cooldown:
+    # Local reference validates reusable workflow changes in this repository.
+    uses: ./.github/workflows/renovate-pr-cooldown.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write

--- a/.github/workflows/renovate-pr-cooldown.yml
+++ b/.github/workflows/renovate-pr-cooldown.yml
@@ -1,0 +1,138 @@
+---
+name: Reusable — Renovate PR cooldown
+
+# Enforces a "soak" period for Renovate PRs whose source registry does not
+# expose a trusted release timestamp (e.g. ghcr.io / lscr.io / quay.io). For
+# those registries the Renovate presets use `minimumReleaseAgeBehaviour:
+# timestamp-optional`, so Renovate opens the PR immediately instead of blocking
+# it forever. This workflow re-introduces the soak as a required
+# `pr-cooldown` status check that only turns green once the PR branch head
+# commit is at least `cooldown-days` old — measured from the commit so a rebase
+# to a newer version correctly restarts the clock. GitHub auto-merge
+# (Renovate `platformAutomerge`) then merges the PR once the check passes.
+#
+# Non-gated PRs (human PRs, or Renovate PRs from registries that DO provide a
+# trusted timestamp) always receive a passing status so the required check
+# never blocks them. See docs/design-decisions/0005-pr-age-cooldown-for-
+# untrusted-timestamps.md.
+
+on:
+  workflow_call:
+    inputs:
+      cooldown-days:
+        description: "Days a gated PR must soak before its status check passes."
+        required: false
+        type: number
+        default: 14
+      gated-branch-prefixes:
+        description: >-
+          Comma-separated Renovate branch prefixes to gate (registries without
+          a trusted release timestamp).
+        required: false
+        type: string
+        default: "renovate/ghcr.io-,renovate/lscr.io-,renovate/quay.io-"
+      renovate-bot-login:
+        description: "Login of the account that opens Renovate PRs."
+        required: false
+        type: string
+        default: "renovate[bot]"
+      status-context:
+        description: "Commit status context name (add this to required checks)."
+        required: false
+        type: string
+        default: "pr-cooldown"
+
+permissions:
+  contents: read
+
+jobs:
+  cooldown:
+    name: pr-cooldown
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Evaluate PR cooldown
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COOLDOWN_DAYS: ${{ inputs.cooldown-days }}
+          GATED_PREFIXES: ${{ inputs.gated-branch-prefixes }}
+          BOT_LOGIN: ${{ inputs.renovate-bot-login }}
+          STATUS_CONTEXT: ${{ inputs.status-context }}
+        with:
+          script: |-
+            const cooldownDays = Number(process.env.COOLDOWN_DAYS) || 14;
+            const context_name = process.env.STATUS_CONTEXT || 'pr-cooldown';
+            const botLogin = process.env.BOT_LOGIN || 'renovate[bot]';
+            const prefixes = (process.env.GATED_PREFIXES || '')
+              .split(',')
+              .map((p) => p.trim())
+              .filter(Boolean);
+            const { owner, repo } = context.repo;
+            const dayMs = 24 * 60 * 60 * 1000;
+
+            const isGated = (branch) =>
+              prefixes.some((prefix) => branch.startsWith(prefix));
+
+            const setStatus = async (sha, state, description) => {
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha,
+                state,
+                context: context_name,
+                description: description.slice(0, 140),
+              });
+            };
+
+            let pulls;
+            if (context.eventName === 'pull_request') {
+              pulls = [context.payload.pull_request];
+            } else {
+              pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+            }
+
+            for (const pr of pulls) {
+              const sha = pr.head.sha;
+              const branch = pr.head.ref;
+              const author = pr.user && pr.user.login;
+
+              if (author !== botLogin || !isGated(branch)) {
+                await setStatus(sha, 'success', 'No cooldown required');
+                continue;
+              }
+
+              const commit = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: sha,
+              });
+              const committedAt = new Date(commit.data.commit.committer.date);
+              const ageDays = (Date.now() - committedAt.getTime()) / dayMs;
+
+              if (ageDays >= cooldownDays) {
+                await setStatus(
+                  sha,
+                  'success',
+                  `Cooldown complete (${cooldownDays}-day soak met)`,
+                );
+                core.info(`PR #${pr.number} (${branch}): cooldown met`);
+              } else {
+                const remaining = Math.max(1, Math.ceil(cooldownDays - ageDays));
+                await setStatus(
+                  sha,
+                  'pending',
+                  `Soaking: ${remaining} day(s) left of ${cooldownDays}-day cooldown`,
+                );
+                core.info(
+                  `PR #${pr.number} (${branch}): ${remaining} day(s) left`,
+                );
+              }
+            }

--- a/.renovate/base.json5
+++ b/.renovate/base.json5
@@ -8,12 +8,13 @@
   pinDigests: true,
   rangeStrategy: "pin",
   minimumReleaseAge: "14 days",
-  // Skip versions still inside their minimumReleaseAge soak and propose the
-  // highest already-soaked version instead of parking the update on the newest
-  // (still-pending) release. Without this, frequently-releasing dependencies
-  // stay stuck under the dependency dashboard's "Pending Status Checks" section
-  // and their PRs are never created (their renovate/stability-days check never
-  // clears). See DevSecNinja/truenas-apps#115.
+  // Keep the strict default explicit: for datasources that DO expose a trusted
+  // release timestamp (docker.io, github tags/releases), hold an update until
+  // the highest already-soaked version passes minimumReleaseAge rather than
+  // opening a PR for a still-pending release. Registries without a trusted
+  // timestamp are handled separately in packageRules.json5 (timestamp-optional
+  // + the pr-cooldown status check). See DevSecNinja/truenas-apps#115 and
+  // docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.
   internalChecksFilter: "strict",
   labels: ["dependencies"],
   osvVulnerabilityAlerts: true,

--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -53,6 +53,16 @@
       minimumReleaseAge: "14 days",
     },
     {
+      description: "ghcr.io / lscr.io / quay.io do not expose a trusted release timestamp, so the default timestamp-required behaviour marks every release 'pending' forever and no PR is ever created. Treat missing timestamps as stable so Renovate opens the PR (and enables automerge); the 14-day soak is instead enforced by the pr-cooldown required status check. Placed after the generic docker rule so it wins. See docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "/^ghcr\\.io\\//",
+        "/^lscr\\.io\\//",
+        "/^quay\\.io\\//",
+      ],
+      minimumReleaseAgeBehaviour: "timestamp-optional",
+    },
+    {
       description: "Auto-merge dotfiles devcontainer image digest, patch, and minor updates via branch without tests, ignoring the global schedule and release-age soak so they can always merge. Placed after the generic docker minimumReleaseAge rule so its minimumReleaseAge:0 wins. Major bumps are intentionally excluded and left for manual review.",
       matchManagers: ["devcontainer"],
       matchDatasources: ["docker"],

--- a/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
+++ b/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
@@ -1,0 +1,98 @@
+# ADR 0005: PR-age cooldown for registries without a trusted release timestamp
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 0004](0004-automerge-non-major-after-soak.md) makes the `minimumReleaseAge`
+soak (`14 days`, in [`.renovate/base.json5`](../../.renovate/base.json5)) a
+load-bearing control: broad auto-merge is only safe because obviously bad
+releases have time to be yanked or superseded before they merge.
+
+Renovate's `minimumReleaseAge` is enforced from a **release timestamp** that the
+datasource/registry must provide. Renovate 42+ defaults
+`minimumReleaseAgeBehaviour` to `timestamp-required`, and it deliberately does
+**not** trust the OCI `org.opencontainers.image.created` annotation (the
+publisher controls it, so it could be forged to bypass the soak).
+
+Several registries we use — **ghcr.io, lscr.io, quay.io** — expose no trusted
+timestamp. With `timestamp-required`, every release from those registries is
+marked "pending" forever: `internalChecksFilter: strict` then refuses to create
+a branch, so the update sits under the dependency dashboard's "Pending Status
+Checks" section and **no PR is ever opened** (observed in
+`DevSecNinja/truenas-apps#115` — e.g. `ghcr.io/italypaleale/traefik-forward-auth`
+stuck for months). The Renovate logs show it plainly:
+
+```text
+Marking N release(s) as pending, as they do not have a releaseTimestamp
+  and we're running with minimumReleaseAgeBehaviour=timestamp-required
+Branch renovate/ghcr.io-…-4.x creation is disabled
+  because internalChecksFilter was not met
+```
+
+The two native options are both unacceptable on their own:
+
+- `timestamp-required` (default): correct soak, but these updates never merge.
+- `timestamp-optional`: PRs open again, but the soak is **skipped entirely** for
+  timestamp-less releases — auto-merge with zero soak, contradicting ADR 0004.
+
+## Decision
+
+Keep the soak, but for these registries **measure it from PR age instead of
+release age**.
+
+1. For `docker` deps on `ghcr.io` / `lscr.io` / `quay.io`, set
+   `minimumReleaseAgeBehaviour: "timestamp-optional"` (in
+   [`.renovate/packageRules.json5`](../../.renovate/packageRules.json5)). Renovate
+   opens the PR immediately and enables `platformAutomerge`.
+2. A required **`pr-cooldown`** status check holds the merge until the PR branch
+   head commit is at least 14 days old, provided by the reusable workflow
+   [`renovate-pr-cooldown.yml`](../../.github/workflows/renovate-pr-cooldown.yml).
+   GitHub auto-merge then merges the PR the moment the check turns green.
+
+Age is measured from the **branch head commit**, not PR creation: when Renovate
+rebases the PR to a newer version the clock correctly restarts, so the exact
+content being merged has always soaked for the full period.
+
+Datasources that DO provide a trusted timestamp (docker.io, github
+tags/releases) are left on the default `timestamp-required` +
+`internalChecksFilter: strict` path — their soak is enforced natively and they
+are not gated by `pr-cooldown`.
+
+## Consuming-repo wiring
+
+A repo that hosts images from the gated registries must:
+
+1. Add a caller workflow from
+   [`workflow-templates/renovate-pr-cooldown.yml`](../../workflow-templates/renovate-pr-cooldown.yml)
+   (triggers: `pull_request`, `schedule`, `workflow_dispatch`).
+2. Add the `pr-cooldown` status check to the branch ruleset's **required status
+   checks**. The workflow reports `success` for human and non-gated PRs, so the
+   required check never blocks anything else.
+
+## Alternatives considered
+
+- **`timestamp-optional` alone.** Rejected: removes the soak for exactly the
+  images most in need of it (no timestamp = no scrutiny window).
+- **Stay on `timestamp-required`.** Rejected: the updates never merge and pile
+  up on the dashboard, so they get force-created manually or ignored.
+- **Custom datasource/regex to synthesise a timestamp.** Rejected: the only
+  available timestamp is the publisher-controlled OCI annotation Renovate
+  intentionally distrusts, so this would re-introduce the forgery risk.
+- **Gate every registry (incl. docker.io) with `pr-cooldown`.** Rejected:
+  double-soaks images that already have a trusted timestamp; only registries
+  without one need the PR-age fallback.
+
+## Consequences
+
+- Updates from ghcr.io / lscr.io / quay.io flow again and auto-merge after a
+  14-day PR-age soak, preserving the ADR 0004 risk posture without trusting a
+  forgeable timestamp.
+- The soak clock for these registries starts when Renovate first opens (or last
+  rebases) the PR rather than at publish time; because Renovate opens the PR
+  shortly after detecting a release, the two are close in practice.
+- `pr-cooldown` becomes a load-bearing required check: it must stay in the
+  branch ruleset, and the scheduled workflow must keep running for soaked PRs to
+  merge.

--- a/docs/design-decisions/README.md
+++ b/docs/design-decisions/README.md
@@ -11,9 +11,10 @@ that supersedes the old one.
 
 ## Index
 
-| ADR                                              | Title                                                | Status   |
-| ------------------------------------------------ | ---------------------------------------------------- | -------- |
-| [0001](0001-reusable-workflow-version-inputs.md) | Reusable workflows must not default package versions | Accepted |
-| [0002](0002-runtime-ci-hardening.md)             | Use Harden-Runner for runtime CI hardening           | Accepted |
-| [0003](0003-task-runner-choice.md)               | Use mise tasks as the task runner                    | Accepted |
-| [0004](0004-automerge-non-major-after-soak.md)   | Auto-merge all non-major updates after a soak period | Accepted |
+| ADR                                                      | Title                                                              | Status   |
+| -------------------------------------------------------- | ------------------------------------------------------------------ | -------- |
+| [0001](0001-reusable-workflow-version-inputs.md)         | Reusable workflows must not default package versions               | Accepted |
+| [0002](0002-runtime-ci-hardening.md)                     | Use Harden-Runner for runtime CI hardening                         | Accepted |
+| [0003](0003-task-runner-choice.md)                       | Use mise tasks as the task runner                                  | Accepted |
+| [0004](0004-automerge-non-major-after-soak.md)           | Auto-merge all non-major updates after a soak period               | Accepted |
+| [0005](0005-pr-age-cooldown-for-untrusted-timestamps.md) | PR-age cooldown for registries without a trusted release timestamp | Accepted |

--- a/workflow-templates/renovate-pr-cooldown.properties.json
+++ b/workflow-templates/renovate-pr-cooldown.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Renovate PR cooldown",
+    "description": "Enforces a 14-day PR-age soak for Renovate PRs from registries without a trusted release timestamp (ghcr.io/lscr.io/quay.io) via a required pr-cooldown status check, so they can auto-merge after soaking. Add pr-cooldown to the branch ruleset's required checks.",
+    "categories": ["Continuous integration", "Dependency management"],
+    "filePatterns": ["renovate\\.json5?$"]
+}

--- a/workflow-templates/renovate-pr-cooldown.yml
+++ b/workflow-templates/renovate-pr-cooldown.yml
@@ -1,0 +1,24 @@
+---
+name: Renovate PR cooldown
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cooldown:
+    uses: DevSecNinja/.github/.github/workflows/renovate-pr-cooldown.yml@46c8d52b2f3ca613956756a583332ba84b7f938e # main
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+      # Optional overrides (defaults shown):
+      # with:
+      #   cooldown-days: 14
+      #   gated-branch-prefixes: "renovate/ghcr.io-,renovate/lscr.io-,renovate/quay.io-"
+      #   status-context: "pr-cooldown"


### PR DESCRIPTION
## Problem

Verified against the latest Renovate run log for `DevSecNinja/truenas-apps` (Renovate 43.280.0):

```text
Marking N release(s) as pending, as they do not have a releaseTimestamp
  and we're running with minimumReleaseAgeBehaviour=timestamp-required
Branch renovate/ghcr.io-…traefik-forward-auth-4.x creation is disabled
  because internalChecksFilter was not met
```

Renovate v42+ defaults **`minimumReleaseAgeBehaviour: timestamp-required`** and deliberately does **not** trust the publisher-controlled OCI `org.opencontainers.image.created` annotation. Images from **ghcr.io / lscr.io / quay.io** expose no trusted release timestamp, so every release is marked *pending* and `internalChecksFilter: strict` refuses to open a branch. The update parks under the dashboard's *"Pending Status Checks"* section and **no PR is ever created** — **30 of 35** branches were blocked this way, incl. `traefik-forward-auth` (stuck at `4.8.0` since March, ref DevSecNinja/truenas-apps#115).

Neither native option alone is acceptable: `timestamp-required` never merges these; `timestamp-optional` opens PRs but **skips the soak entirely**, contradicting [ADR 0004](docs/design-decisions/0004-automerge-non-major-after-soak.md).

## Solution — measure the soak from PR age for these registries

- **`.renovate/packageRules.json5`**: `minimumReleaseAgeBehaviour: "timestamp-optional"` scoped to `docker` deps on `ghcr.io`/`lscr.io`/`quay.io` → Renovate opens the PR and enables `platformAutomerge`.
- **`.github/workflows/renovate-pr-cooldown.yml`** (new reusable workflow): posts a required **`pr-cooldown`** commit status that stays `pending` until the PR **branch head commit** is ≥ 14 days old (a rebase to a newer version restarts the clock). GitHub auto-merge merges the moment it turns green. Human and non-gated PRs always get `success`, so the required check never blocks anything else.
- Local caller (`renovate-pr-cooldown-caller.yml`), `workflow-templates/` entry + `.properties.json` for adoption.
- **ADR 0005** documents the decision; the misleading `base.json5` `internalChecksFilter` comment from #284 is corrected (strict is the right default for the *timestamp-required* path, not the fix for the stuck updates).

Datasources with trusted timestamps (docker.io, github tags/releases) keep the native soak and are **not** gated by `pr-cooldown`.

## Consuming-repo wiring (per ADR 0005)

1. Add the caller workflow from `workflow-templates/renovate-pr-cooldown.yml` (triggers: `pull_request`, `schedule`, `workflow_dispatch`).
2. Add `pr-cooldown` to the branch ruleset's **required status checks**.

## Validation

`actionlint`, `zizmor` (no findings), `yamllint`, `yamlfmt -lint`, `dprint check` all clean (via `config-sync/files` configs); JSON5 presets parse; embedded github-script `node --check` + a mocked decision matrix (gated-old→success, gated-new→pending, docker.io→pass, human→pass) all correct.

## Caveat

docker.io images that also lack a timestamp (e.g. dozzle/cloudflared/mongo) are intentionally **not** gated here, per "only the registries we know are unreliable." They can be added to `gated-branch-prefixes` + the packageRule later if desired.

Refs DevSecNinja/truenas-apps#115