### PR TITLE
feat(pages): add optional go-version input

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,21 @@ on:
         required: false
         type: string
         default: ""
+      go-version:
+        description: >-
+          Go version to install before the build. Required for Hugo Modules and
+          any other build step that shells out to Go; leave empty to skip Go
+          setup. Without it the build silently uses whatever Go the runner
+          image happens to ship.
+        required: false
+        type: string
+        default: ""
+      go-version-file:
+        description: >-
+          File to read the Go version from, used only when go-version is empty.
+        required: false
+        type: string
+        default: ""
       wrangler-version:
         description: >-
           Wrangler version for Cloudflare Pages deploys. Required when
@@ -294,6 +309,13 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.node-cache }}
 
+      - name: Setup Go
+        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+
       - name: Install dependencies
         if: ${{ inputs.install-command != '' }}
         env:
@@ -358,6 +380,13 @@ jobs:
           # These jobs run only on merge to the production branch, so the lost
           # package-download caching is negligible; test/preview keep it.
           package-manager-cache: false
+
+      - name: Setup Go
+        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}
@@ -454,6 +483,13 @@ jobs:
           # package-download caching is negligible; test/preview keep it.
           package-manager-cache: false
 
+      - name: Setup Go
+        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}
         env:
@@ -537,6 +573,13 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: false
+
+      - name: Setup Go
+        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -387,6 +387,9 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           go-version-file: ${{ inputs.go-version-file }}
+          # Caching disabled on this privileged job to remove the
+          # cache-poisoning surface (zizmor), matching setup-node above.
+          cache: false
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}
@@ -489,6 +492,9 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           go-version-file: ${{ inputs.go-version-file }}
+          # Caching disabled on this privileged job to remove the
+          # cache-poisoning surface (zizmor), matching setup-node above.
+          cache: false
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}
@@ -580,6 +586,9 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           go-version-file: ${{ inputs.go-version-file }}
+          # Caching disabled on this privileged job to remove the
+          # cache-poisoning surface (zizmor), matching setup-node above.
+          cache: false
 
       - name: Install dependencies
         if: ${{ inputs.build-command != '' && inputs.install-command != '' }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,32 +136,32 @@ optionally deploys same-repository pull request previews to Cloudflare Pages.
 Cloudflare jobs detect missing Cloudflare secrets before any deploy work. Missing
 secrets fail production Cloudflare deploys and skip preview-only deploys.
 
-| Input                              | Description                                                                                     |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `node-version`                     | **Required.** Node.js version to install.                                                       |
-| `node-cache`                       | Package manager cache for test and production jobs. Default: empty (disabled).                  |
-| `go-version`                       | Go version to install before the build. Required for Hugo Modules. Default: empty (no Go setup).|
-| `go-version-file`                  | File to read the Go version from, used only when `go-version` is empty.                         |
-| `wrangler-version`                 | **Required.** Wrangler version to install for previews; inputs cannot be conditional.           |
-| `production-branch`                | Branch that deploys to production. Default: `main`.                                             |
-| `artifact-path`                    | Directory uploaded to Pages. Default: `.`.                                                      |
-| `install-command`                  | Dependency install command. Default: `npm ci`.                                                  |
-| `test-command`                     | Validation command block. Default: empty.                                                       |
-| `test-setup-command`               | Optional command after install and before tests.                                                |
-| `build-command`                    | Optional build command before deployment.                                                       |
-| `pre-deploy-command`               | Optional production-only pre-upload command.                                                    |
-| `pre-preview-command`              | Optional preview-only pre-deploy command.                                                       |
-| `update-sitemap-lastmod`           | Update sitemap `<lastmod>` dates. Default: `false`.                                             |
-| `sitemap-path`                     | Sitemap file path. Default: `sitemap.xml`.                                                      |
-| `github-pages`                     | Deploy production to GitHub Pages. Default: `true`.                                             |
-| `cloudflare-preview`               | Enable Cloudflare pull request previews. Default: `true`.                                       |
-| `cloudflare-production`            | Deploy production to Cloudflare Pages. Default: `false`.                                        |
-| `cloudflare-production-on-release` | Deploy Cloudflare production only on `release` events, not every main commit. Default: `false`. |
-| `cloudflare-acceptance`            | Deploy an acceptance build to Cloudflare on main commits. Default: `false`.                     |
-| `cloudflare-acceptance-branch`     | Cloudflare branch name for acceptance deploys. Default: `acceptance`.                           |
-| `cloudflare-project-name`          | Cloudflare Pages project; lowercase letters, numbers, and hyphens only.                         |
-| `cloudflare-production-branch`     | Cloudflare production branch. Default: `main`.                                                  |
-| `preview-comment-marker`           | Marker used to update the preview PR comment.                                                   |
+| Input                              | Description                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `node-version`                     | **Required.** Node.js version to install.                                                        |
+| `node-cache`                       | Package manager cache for test and production jobs. Default: empty (disabled).                   |
+| `go-version`                       | Go version to install before the build. Required for Hugo Modules. Default: empty (no Go setup). |
+| `go-version-file`                  | File to read the Go version from, used only when `go-version` is empty.                          |
+| `wrangler-version`                 | **Required.** Wrangler version to install for previews; inputs cannot be conditional.            |
+| `production-branch`                | Branch that deploys to production. Default: `main`.                                              |
+| `artifact-path`                    | Directory uploaded to Pages. Default: `.`.                                                       |
+| `install-command`                  | Dependency install command. Default: `npm ci`.                                                   |
+| `test-command`                     | Validation command block. Default: empty.                                                        |
+| `test-setup-command`               | Optional command after install and before tests.                                                 |
+| `build-command`                    | Optional build command before deployment.                                                        |
+| `pre-deploy-command`               | Optional production-only pre-upload command.                                                     |
+| `pre-preview-command`              | Optional preview-only pre-deploy command.                                                        |
+| `update-sitemap-lastmod`           | Update sitemap `<lastmod>` dates. Default: `false`.                                              |
+| `sitemap-path`                     | Sitemap file path. Default: `sitemap.xml`.                                                       |
+| `github-pages`                     | Deploy production to GitHub Pages. Default: `true`.                                              |
+| `cloudflare-preview`               | Enable Cloudflare pull request previews. Default: `true`.                                        |
+| `cloudflare-production`            | Deploy production to Cloudflare Pages. Default: `false`.                                         |
+| `cloudflare-production-on-release` | Deploy Cloudflare production only on `release` events, not every main commit. Default: `false`.  |
+| `cloudflare-acceptance`            | Deploy an acceptance build to Cloudflare on main commits. Default: `false`.                      |
+| `cloudflare-acceptance-branch`     | Cloudflare branch name for acceptance deploys. Default: `acceptance`.                            |
+| `cloudflare-project-name`          | Cloudflare Pages project; lowercase letters, numbers, and hyphens only.                          |
+| `cloudflare-production-branch`     | Cloudflare production branch. Default: `main`.                                                   |
+| `preview-comment-marker`           | Marker used to update the preview PR comment.                                                    |
 
 Build, pre-deploy, and pre-preview commands run with an `APP_COMMIT_SHA`
 environment variable set to `${{ github.event.pull_request.head.sha || github.sha }}`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,8 @@ secrets fail production Cloudflare deploys and skip preview-only deploys.
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `node-version`                     | **Required.** Node.js version to install.                                                       |
 | `node-cache`                       | Package manager cache for test and production jobs. Default: empty (disabled).                  |
+| `go-version`                       | Go version to install before the build. Required for Hugo Modules. Default: empty (no Go setup).|
+| `go-version-file`                  | File to read the Go version from, used only when `go-version` is empty.                         |
 | `wrangler-version`                 | **Required.** Wrangler version to install for previews; inputs cannot be conditional.           |
 | `production-branch`                | Branch that deploys to production. Default: `main`.                                             |
 | `artifact-path`                    | Directory uploaded to Pages. Default: `.`.                                                      |
@@ -191,6 +193,10 @@ jobs:
       node-version: "24"
       # renovate: datasource=npm depName=wrangler
       wrangler-version: "3"
+      # Required when the site resolves a theme through Hugo Modules, which
+      # shells out to Go. Without it the runner's preinstalled Go is used.
+      # renovate: datasource=golang-version depName=go
+      go-version: "1.26.5"
       test-setup-command: npx playwright install webkit --with-deps
       test-command: |
         npm run test:unit


### PR DESCRIPTION
## Problem

`pages.yml` sets up Node, but never Go. Sites that resolve their theme through [Hugo Modules](https://gohugo.io/hugo-modules/) shell out to Go during the build, so those builds use whatever Go version the `ubuntu-24.04` image happens to ship.

That is not pinned, not reproducible, and changes silently when GitHub updates the runner image. It also means a repository can pin Go in `.mise.toml` for local development and still build against a different version in CI.

## Change

Two new optional inputs, `go-version` and `go-version-file`, following the same pattern as the existing Node inputs and reusing the `actions/setup-go` SHA already pinned in `lint.yml`.

A `Setup Go` step is added to all four jobs that build (`test`, `deploy`, `deploy-cloudflare`, `deploy-preview`), each guarded by:

```yaml
if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
```

## Compatibility

Both inputs default to `""`, so the step is skipped and **existing callers are unaffected**. Purely additive: 43 insertions, 0 deletions in the workflow.

## Verification

- `actionlint` passes
- `yamlfmt -lint -conf config-sync/files/.yamlfmt.yaml` passes
- Docs updated in `docs/architecture.md`, including a Renovate-annotated example

## Caller side

`DevSecNinja/scratchpad` consumes PaperMod as a Hugo Module and is the repository that surfaced this.