### PR TITLE
feat(pages): add opt-in BUILD_GITHUB_TOKEN for production builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -142,6 +142,15 @@ on:
         required: false
       CLOUDFLARE_ACCOUNT_ID:
         required: false
+      BUILD_GITHUB_TOKEN:
+        description: >-
+          Optional token exposed to `build-command` as `GITHUB_TOKEN`, for
+          builds that read the GitHub API (e.g. a site generated from Issues).
+          Only ever exposed to production-branch builds — never to the test job
+          or to pull request preview builds, which run untrusted PR head code.
+          Pass the caller's `github.token` and scope it with the caller job's
+          `permissions:` block, or supply a narrower token.
+        required: false
 
 permissions:
   contents: read
@@ -401,7 +410,17 @@ jobs:
         if: ${{ inputs.build-command != '' }}
         env:
           BUILD_COMMAND: ${{ inputs.build-command }}
-        run: bash -euo pipefail -c "${BUILD_COMMAND}"
+          BUILD_GITHUB_TOKEN: ${{ secrets.BUILD_GITHUB_TOKEN }}
+        run: |-
+          set -euo pipefail
+          # Opt-in: only export a token when the caller actually supplied one,
+          # so builds that need none never see an empty GITHUB_TOKEN. This job
+          # only runs on the production branch, so the build command is trusted
+          # default-branch code (unlike the preview job below).
+          if [ -n "${BUILD_GITHUB_TOKEN}" ]; then
+            export GITHUB_TOKEN="${BUILD_GITHUB_TOKEN}"
+          fi
+          bash -euo pipefail -c "${BUILD_COMMAND}"
 
       - name: Run pre-deploy command
         if: ${{ inputs.pre-deploy-command != '' }}
@@ -506,7 +525,17 @@ jobs:
         if: ${{ inputs.build-command != '' }}
         env:
           BUILD_COMMAND: ${{ inputs.build-command }}
-        run: bash -euo pipefail -c "${BUILD_COMMAND}"
+          BUILD_GITHUB_TOKEN: ${{ secrets.BUILD_GITHUB_TOKEN }}
+        run: |-
+          set -euo pipefail
+          # Opt-in: only export a token when the caller actually supplied one,
+          # so builds that need none never see an empty GITHUB_TOKEN. This job
+          # only runs on the production branch, so the build command is trusted
+          # default-branch code (unlike the preview job below).
+          if [ -n "${BUILD_GITHUB_TOKEN}" ]; then
+            export GITHUB_TOKEN="${BUILD_GITHUB_TOKEN}"
+          fi
+          bash -euo pipefail -c "${BUILD_COMMAND}"
 
       - name: Run pre-deploy command
         if: ${{ inputs.pre-deploy-command != '' }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,10 +163,35 @@ secrets fail production Cloudflare deploys and skip preview-only deploys.
 | `cloudflare-production-branch`     | Cloudflare production branch. Default: `main`.                                                   |
 | `preview-comment-marker`           | Marker used to update the preview PR comment.                                                    |
 
+| Secret                | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare API token. Required for any Cloudflare deploy.                            |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID. Required for any Cloudflare deploy.                           |
+| `BUILD_GITHUB_TOKEN`    | Optional. Exposed to `build-command` as `GITHUB_TOKEN` on production builds only.    |
+
 Build, pre-deploy, and pre-preview commands run with an `APP_COMMIT_SHA`
 environment variable set to `${{ github.event.pull_request.head.sha || github.sha }}`.
 On `pull_request` events `github.sha` is the ephemeral merge commit, so builds
 should read `APP_COMMIT_SHA` to stamp the real PR head commit in previews.
+
+**Builds that need the GitHub API.** Sites generated from repository data (for
+example a site built from GitHub Issues) can pass `BUILD_GITHUB_TOKEN`. It is
+exported as `GITHUB_TOKEN` for the `build-command` step of the GitHub Pages and
+Cloudflare production/acceptance deploy jobs *only* — never for the test job or
+for pull request previews, which build untrusted PR head code. Previews
+therefore build without a token and should fall back to committed fixture data.
+Scope the token with the caller's own `permissions:` block, e.g.:
+
+```yaml
+    permissions:
+      contents: read
+      issues: read
+      # …plus the deploy permissions
+    secrets:
+      BUILD_GITHUB_TOKEN: ${{ github.token }}
+```
+
+See [ADR 0006](design-decisions/0006-build-time-github-token.md).
 
 **Example caller:**
 

--- a/docs/design-decisions/0006-build-time-github-token.md
+++ b/docs/design-decisions/0006-build-time-github-token.md
@@ -1,0 +1,77 @@
+# ADR 0006: Build-time GitHub token for Pages, production builds only
+
+## Status
+
+Accepted
+
+## Context
+
+Some sites deployed through the shared `pages.yml` workflow are generated from
+data that lives in the GitHub API rather than in the repository — for example a
+static site whose content is built from published GitHub Issues. Those builds
+need an authenticated GitHub API call at build time.
+
+`pages.yml` runs the caller-supplied `build-command` in three different jobs:
+
+- `deploy` (GitHub Pages) — runs only on the production branch.
+- `deploy-cloudflare` (production / acceptance) — runs only on the production
+  branch.
+- `deploy-preview` (Cloudflare PR previews) — checks out and builds the
+  **pull request head**, i.e. code that a contributor can change in the PR.
+
+Handing a token to a build command is handing it to arbitrary code. In the
+preview job that code is attacker-controlled from the moment a PR is opened
+(the job is already restricted to same-repository PRs and non-bot actors, but
+that still includes anyone who can push a branch). A token exposed there could
+be exfiltrated, and workflow secret masking does not prevent a build script from
+transforming and leaking a value it can read.
+
+## Decision
+
+Add an **optional** `BUILD_GITHUB_TOKEN` secret to `pages.yml`, subject to four
+constraints:
+
+1. **Opt-in.** Callers that do not pass the secret see no behaviour change, and
+   no `GITHUB_TOKEN` variable is set at all — the build step exports it only
+   when the value is non-empty, so a build never receives an empty token.
+2. **Production builds only.** It is exposed to the `build-command` step of the
+   `deploy` and `deploy-cloudflare` jobs, which run exclusively on the
+   production branch and therefore build reviewed, merged code. It is *not*
+   exposed to `deploy-preview` or to the `test` job.
+3. **Step-scoped.** It is set as `env:` on the single build step rather than
+   written to `$GITHUB_ENV`, so later steps in the same job (including the
+   Wrangler deploy) never see it.
+4. **Caller-scoped privileges.** The workflow does not mint or widen a token of
+   its own. The caller passes one explicitly — typically `${{ github.token }}`
+   narrowed by its own `permissions:` block (e.g. `issues: read`).
+
+## Alternatives considered
+
+- **Expose the token in every job, including previews.** Rejected: it would put
+  a repository token in the hands of unreviewed pull request code.
+- **A generic `build-env` string input.** Rejected: an arbitrary key/value
+  string cannot be masked by Actions secret masking, invites callers to smuggle
+  secrets through a plain input, and is far harder to reason about than one
+  named, purpose-built secret.
+- **Always set `GITHUB_TOKEN` from the secret, empty when absent.** Rejected:
+  an empty-but-set `GITHUB_TOKEN` changes the behaviour of tools that check
+  only for the variable's presence.
+- **Write the token to `$GITHUB_ENV`.** Rejected: it would leak into every
+  subsequent step of the job for no benefit.
+- **Let callers fetch data in their own workflow and commit it.** Rejected as a
+  general answer: it produces bot commits on every content change and couples
+  content updates to the git history.
+- **Unauthenticated GitHub API calls from the build.** Rejected: the 60
+  requests/hour per-IP limit is shared across GitHub-hosted runners.
+
+## Consequences
+
+- Pull request previews build without a token. Sites that need API data must
+  fall back to committed fixture data in previews, which keeps preview builds
+  hermetic but means a preview can show slightly stale or sample content.
+- Only production-branch builds can reach the GitHub API, so a build-time API
+  regression is not caught until merge. Callers should keep the fixture-based
+  path exercised by their test suite.
+- The blast radius of a compromised build script on the production branch now
+  includes the caller-scoped token; callers must keep their `permissions:`
+  block minimal.

--- a/docs/design-decisions/README.md
+++ b/docs/design-decisions/README.md
@@ -18,3 +18,4 @@ that supersedes the old one.
 | [0003](0003-task-runner-choice.md)                       | Use mise tasks as the task runner                                  | Accepted |
 | [0004](0004-automerge-non-major-after-soak.md)           | Auto-merge all non-major updates after a soak period               | Accepted |
 | [0005](0005-pr-age-cooldown-for-untrusted-timestamps.md) | PR-age cooldown for registries without a trusted release timestamp | Accepted |
+| [0006](0006-build-time-github-token.md)                  | Build-time GitHub token for Pages, production builds only          | Accepted |


### PR DESCRIPTION
## Why

Some sites deployed through this workflow are generated from data that lives in the GitHub API rather than in the repository — for example a static site built from published GitHub Issues. Those builds need an authenticated API call at build time, and `pages.yml` currently exposes no token to `build-command`.

## What

Adds an **optional** `BUILD_GITHUB_TOKEN` secret, exported as `GITHUB_TOKEN` for the `build-command` step.

The interesting part is where it is *not* available. `pages.yml` runs `build-command` in three jobs, and one of them — `deploy-preview` — checks out and builds the **pull request head**, i.e. code a contributor controls. Handing a token to a build command is handing it to arbitrary code, and secret masking does not stop a build script from transforming and leaking a value it can read.

So the secret is constrained four ways:

1. **Opt-in.** Callers that don't pass it see no change, and no `GITHUB_TOKEN` is set *at all* — the step exports it only when non-empty, so a build never receives an empty token (which would change the behaviour of tools that only check for presence).
2. **Production builds only.** Exposed to the `build-command` step of `deploy` (GitHub Pages) and `deploy-cloudflare` (production/acceptance), which run exclusively on the production branch and therefore build reviewed, merged code. Never in `deploy-preview` or the `test` job.
3. **Step-scoped.** Set as `env:` on the single build step, not written to `$GITHUB_ENV`, so later steps in the job (including the Wrangler deploy) never see it.
4. **Caller-scoped privileges.** The workflow mints nothing. The caller passes a token explicitly — typically its own `github.token` narrowed by its `permissions:` block.

## Usage

```yaml
    permissions:
      contents: read
      issues: read
      # …plus the deploy permissions
    with:
      build-command: npm run build
    secrets:
      BUILD_GITHUB_TOKEN: ${{ github.token }}
```

## Trade-off

Pull request previews build without a token, so sites needing API data must fall back to committed fixture data in previews. That keeps preview builds hermetic, but a preview can show sample or slightly stale content — documented in the ADR.

## Also included

- `docs/architecture.md`: a secrets table for `pages.yml` and a section on builds that need the GitHub API.
- `docs/design-decisions/0006-build-time-github-token.md` (ADR) recording the decision and the alternatives rejected — exposing the token everywhere, a generic `build-env` string input (unmaskable), always setting an empty `GITHUB_TOKEN`, `$GITHUB_ENV`, committing fetched data, and unauthenticated API calls.

## Verification

- `actionlint` and `yamllint` clean on the modified workflow.
- Verified the `deploy-preview` build step is unchanged and still tokenless.
- Backwards compatible: no new inputs, and the secret is optional.

The first consumer is [`DevSecNinja/bean-book`](https://github.com/DevSecNinja/bean-book), whose sites are generated from published GitHub Issues.
