### PR TITLE
feat(pages): deploy prebuilt artifacts via artifact-name

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,20 @@ on:
         description: "Path uploaded to GitHub Pages or Cloudflare Pages"
         required: true
         type: string
+      artifact-name:
+        description: >-
+          Name of an artifact, uploaded by an earlier job in the calling
+          workflow, that already contains the built site. When set, the deploy
+          jobs download it into `artifact-path` instead of running
+          `install-command` / `build-command`.
+
+          Use this when the build needs credentials or tooling this workflow
+          does not provide: the build then runs in the caller's own job, where
+          the caller controls the environment, and this workflow only deploys.
+          The calling job must `needs:` the job that uploads the artifact.
+        required: false
+        type: string
+        default: ""
       install-command:
         description: "Dependency installation command"
         required: false
@@ -160,6 +174,7 @@ jobs:
           TEST_SETUP_COMMAND: ${{ inputs.test-setup-command }}
           TEST_COMMAND: ${{ inputs.test-command }}
           BUILD_COMMAND: ${{ inputs.build-command }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
           CLOUDFLARE_PREVIEW: ${{ inputs.cloudflare-preview }}
           CLOUDFLARE_PRODUCTION: ${{ inputs.cloudflare-production }}
           CLOUDFLARE_ACCEPTANCE: ${{ inputs.cloudflare-acceptance }}
@@ -173,6 +188,11 @@ jobs:
             [ -n "${BUILD_COMMAND}" ]
           }; then
             echo "::error::node-version is required when install-command, test-setup-command, test-command, or build-command is set; provide node-version or clear those commands."
+            exit 1
+          fi
+
+          if [ -n "${ARTIFACT_NAME}" ] && [ -n "${BUILD_COMMAND}" ]; then
+            echo "::error::artifact-name and build-command are mutually exclusive; the artifact is deployed as-is."
             exit 1
           fi
 
@@ -382,7 +402,9 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Go
-        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        if: >-
+          ${{ inputs.artifact-name == '' &&
+          (inputs.go-version != '' || inputs.go-version-file != '') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
@@ -402,6 +424,16 @@ jobs:
         env:
           BUILD_COMMAND: ${{ inputs.build-command }}
         run: bash -euo pipefail -c "${BUILD_COMMAND}"
+
+      # Artifacts are scoped to the workflow run, and a reusable workflow's jobs
+      # are part of the caller's run — so this picks up an artifact uploaded by
+      # an earlier caller job with no extra permissions and no token handoff.
+      - name: Download prebuilt site
+        if: ${{ inputs.artifact-name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
 
       - name: Run pre-deploy command
         if: ${{ inputs.pre-deploy-command != '' }}
@@ -487,7 +519,9 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Go
-        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        if: >-
+          ${{ inputs.artifact-name == '' &&
+          (inputs.go-version != '' || inputs.go-version-file != '') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
@@ -507,6 +541,16 @@ jobs:
         env:
           BUILD_COMMAND: ${{ inputs.build-command }}
         run: bash -euo pipefail -c "${BUILD_COMMAND}"
+
+      # Artifacts are scoped to the workflow run, and a reusable workflow's jobs
+      # are part of the caller's run — so this picks up an artifact uploaded by
+      # an earlier caller job with no extra permissions and no token handoff.
+      - name: Download prebuilt site
+        if: ${{ inputs.artifact-name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
 
       - name: Run pre-deploy command
         if: ${{ inputs.pre-deploy-command != '' }}
@@ -581,7 +625,9 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Go
-        if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
+        if: >-
+          ${{ inputs.artifact-name == '' &&
+          (inputs.go-version != '' || inputs.go-version-file != '') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
@@ -601,6 +647,16 @@ jobs:
         env:
           BUILD_COMMAND: ${{ inputs.build-command }}
         run: bash -euo pipefail -c "${BUILD_COMMAND}"
+
+      # Artifacts are scoped to the workflow run, and a reusable workflow's jobs
+      # are part of the caller's run — so this picks up an artifact uploaded by
+      # an earlier caller job with no extra permissions and no token handoff.
+      - name: Download prebuilt site
+        if: ${{ inputs.artifact-name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
 
       - name: Run pre-preview command
         if: ${{ inputs.pre-preview-command != '' }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,6 +145,7 @@ secrets fail production Cloudflare deploys and skip preview-only deploys.
 | `wrangler-version`                 | **Required.** Wrangler version to install for previews; inputs cannot be conditional.            |
 | `production-branch`                | Branch that deploys to production. Default: `main`.                                              |
 | `artifact-path`                    | Directory uploaded to Pages. Default: `.`.                                                       |
+| `artifact-name`                    | Deploy a prebuilt artifact from an earlier caller job instead of building. Default: empty.       |
 | `install-command`                  | Dependency install command. Default: `npm ci`.                                                   |
 | `test-command`                     | Validation command block. Default: empty.                                                        |
 | `test-setup-command`               | Optional command after install and before tests.                                                 |
@@ -167,6 +168,61 @@ Build, pre-deploy, and pre-preview commands run with an `APP_COMMIT_SHA`
 environment variable set to `${{ github.event.pull_request.head.sha || github.sha }}`.
 On `pull_request` events `github.sha` is the ephemeral merge commit, so builds
 should read `APP_COMMIT_SHA` to stamp the real PR head commit in previews.
+
+#### Deploying a prebuilt artifact
+
+This workflow provides a fixed build environment: Node, Go, an install command
+and a build command. A build that needs anything else — a `GITHUB_TOKEN` to
+read the API, a cloud credential, a toolchain that isn't here — should not try
+to smuggle it through more inputs. Build it in your own job and hand over the
+result:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read          # whatever *your* build needs
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: actions/setup-node@<sha>
+        with:
+          node-version: "24"
+      - run: npm ci && npm test && npm run build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/upload-artifact@<sha>
+        with:
+          name: site
+          path: dist
+          # v4+ omits dotfiles; needed for .well-known, .nojekyll, …
+          include-hidden-files: true
+
+  pages:
+    needs: build
+    uses: DevSecNinja/.github/.github/workflows/pages.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+      pages: write
+    with:
+      artifact-name: site
+      artifact-path: dist
+      cloudflare-project-name: my-site
+```
+
+`artifact-name` and `build-command` are mutually exclusive — the artifact is
+deployed exactly as uploaded. With `artifact-name` set the deploy jobs skip
+Node/Go setup, install and build entirely.
+
+Because artifacts are scoped to the workflow run and a reusable workflow's jobs
+run inside the caller's run, no extra permissions and no credential handoff are
+involved. Note that the same artifact is deployed to previews and to
+production; if previews must be built without credentials, branch on
+`github.event_name` in your own build job. See
+[ADR 0006](design-decisions/0006-prebuilt-artifact-deploys.md).
 
 **Example caller:**
 

--- a/docs/design-decisions/0006-prebuilt-artifact-deploys.md
+++ b/docs/design-decisions/0006-prebuilt-artifact-deploys.md
@@ -1,0 +1,83 @@
+# ADR 0006: Deploy prebuilt artifacts instead of passing credentials into builds
+
+## Status
+
+Accepted
+
+## Context
+
+Some sites deployed through the shared `pages.yml` workflow are generated from
+data that is not in the repository — for example a static site built from
+published GitHub Issues. Those builds need an authenticated GitHub API call at
+build time, and `pages.yml` exposes no credentials to `build-command`.
+
+The obvious fix is to add a token secret that the workflow exports for the build
+step. That is uncomfortable, because `pages.yml` runs `build-command` in three
+jobs, and one of them — `deploy-preview` — checks out and builds the **pull
+request head**, i.e. code a contributor controls. Handing a token to a build
+command is handing it to arbitrary code, and Actions secret masking does not
+stop a build script from transforming a value it can read. Any such input has to
+arrive with a careful, easily-forgotten set of caveats about which jobs it
+applies to.
+
+There is a more general problem behind it. `pages.yml` already carries
+`node-version`, `node-cache`, `go-version`, `go-version-file`, `install-command`,
+`test-setup-command`, `test-command` and `build-command`. Every build need that
+the workflow does not anticipate becomes another input and another pull request
+against this repository. The genuinely reusable part of the workflow is
+*deploying a directory* to GitHub Pages and Cloudflare Pages, including project
+creation, preview lifecycle, PR comments and environment wiring. Building is the
+part that varies per repository.
+
+## Decision
+
+Add an optional `artifact-name` input. When set, the deploy jobs download that
+artifact into `artifact-path` and deploy it as-is, skipping Node/Go setup,
+`install-command` and `build-command`. `artifact-name` and `build-command` are
+mutually exclusive and validated as such.
+
+Callers whose build needs credentials or unusual tooling run it in their own job
+— where they already control permissions, secrets and environment — upload the
+result, and have the `uses:` job `needs:` that build job.
+
+**No credential is ever passed into this workflow for the purpose of running
+caller build code.** Artifacts are scoped to a workflow run, and a reusable
+workflow's jobs are part of the caller's run, so the handover needs no extra
+permissions and no token.
+
+`build-command` mode is unchanged and remains the simple path for builds that
+need nothing beyond Node/Go.
+
+## Alternatives considered
+
+- **A `BUILD_GITHUB_TOKEN` secret exported to the build step.** The first
+  attempt. Workable if restricted to the production-branch jobs and never
+  exposed to previews or the test job, but it puts the security of the caller's
+  credential in this workflow's control flow, where a later refactor could
+  quietly widen it. Rejected once `artifact-name` made it unnecessary: keeping
+  both would leave a second, riskier way to do the same job.
+- **A generic `build-env` string input.** Rejected: an arbitrary key/value
+  string cannot be masked by Actions secret masking and invites callers to pass
+  secrets through a plain input.
+- **Keep adding per-need inputs (more toolchains, more env).** Rejected: it
+  grows the shared interface without bound and couples every caller's build
+  requirements to this repository's release cycle.
+- **Let callers fetch data and commit it.** Rejected: bot commits on every
+  content change, and it couples content updates to git history.
+- **Unauthenticated API calls from the build.** Rejected: the 60 requests/hour
+  per-IP limit is shared across GitHub-hosted runners.
+
+## Consequences
+
+- The build/deploy boundary is explicit. This workflow's contract becomes "give
+  me a directory, or a command that produces one, and I will deploy it".
+- Callers using `artifact-name` take on a little more boilerplate: an upload
+  step and a `needs:`.
+- The same artifact is deployed to previews and to production. A caller that
+  wants previews built without credentials must branch on `github.event_name`
+  in its own build job. That decision now lives in the caller's workflow, where
+  it is visible, rather than being an implicit property of this one.
+- `actions/upload-artifact` v4+ omits hidden files unless
+  `include-hidden-files: true` is set, which matters for `.well-known`,
+  `.nojekyll` and similar. Documented in `docs/architecture.md`.
+- Artifact upload and download add roughly 10–20 seconds per deploy.

--- a/docs/design-decisions/0006-prebuilt-artifact-deploys.md
+++ b/docs/design-decisions/0006-prebuilt-artifact-deploys.md
@@ -25,7 +25,7 @@ There is a more general problem behind it. `pages.yml` already carries
 `test-setup-command`, `test-command` and `build-command`. Every build need that
 the workflow does not anticipate becomes another input and another pull request
 against this repository. The genuinely reusable part of the workflow is
-*deploying a directory* to GitHub Pages and Cloudflare Pages, including project
+_deploying a directory_ to GitHub Pages and Cloudflare Pages, including project
 creation, preview lifecycle, PR comments and environment wiring. Building is the
 part that varies per repository.
 

--- a/docs/design-decisions/README.md
+++ b/docs/design-decisions/README.md
@@ -18,3 +18,4 @@ that supersedes the old one.
 | [0003](0003-task-runner-choice.md)                       | Use mise tasks as the task runner                                  | Accepted |
 | [0004](0004-automerge-non-major-after-soak.md)           | Auto-merge all non-major updates after a soak period               | Accepted |
 | [0005](0005-pr-age-cooldown-for-untrusted-timestamps.md) | PR-age cooldown for registries without a trusted release timestamp | Accepted |
+| [0006](0006-prebuilt-artifact-deploys.md)                | Deploy prebuilt artifacts instead of passing credentials into builds | Accepted |

--- a/docs/design-decisions/README.md
+++ b/docs/design-decisions/README.md
@@ -11,11 +11,11 @@ that supersedes the old one.
 
 ## Index
 
-| ADR                                                      | Title                                                              | Status   |
-| -------------------------------------------------------- | ------------------------------------------------------------------ | -------- |
-| [0001](0001-reusable-workflow-version-inputs.md)         | Reusable workflows must not default package versions               | Accepted |
-| [0002](0002-runtime-ci-hardening.md)                     | Use Harden-Runner for runtime CI hardening                         | Accepted |
-| [0003](0003-task-runner-choice.md)                       | Use mise tasks as the task runner                                  | Accepted |
-| [0004](0004-automerge-non-major-after-soak.md)           | Auto-merge all non-major updates after a soak period               | Accepted |
-| [0005](0005-pr-age-cooldown-for-untrusted-timestamps.md) | PR-age cooldown for registries without a trusted release timestamp | Accepted |
+| ADR                                                      | Title                                                                | Status   |
+| -------------------------------------------------------- | -------------------------------------------------------------------- | -------- |
+| [0001](0001-reusable-workflow-version-inputs.md)         | Reusable workflows must not default package versions                 | Accepted |
+| [0002](0002-runtime-ci-hardening.md)                     | Use Harden-Runner for runtime CI hardening                           | Accepted |
+| [0003](0003-task-runner-choice.md)                       | Use mise tasks as the task runner                                    | Accepted |
+| [0004](0004-automerge-non-major-after-soak.md)           | Auto-merge all non-major updates after a soak period                 | Accepted |
+| [0005](0005-pr-age-cooldown-for-untrusted-timestamps.md) | PR-age cooldown for registries without a trusted release timestamp   | Accepted |
 | [0006](0006-prebuilt-artifact-deploys.md)                | Deploy prebuilt artifacts instead of passing credentials into builds | Accepted |


### PR DESCRIPTION
Supersedes #303, which took the obvious-but-uncomfortable route.

## Why

Some sites deployed through this workflow are generated from data that isn't in the repository — a static site built from published GitHub Issues, say. Those builds need an authenticated API call, and `pages.yml` exposes no credentials to `build-command`.

#303 added a token secret for the build step. It was carefully fenced (production jobs only, never previews, step-scoped, caller-scoped), but the discomfort didn't go away: `build-command` also runs in `deploy-preview`, which builds **pull request head code**. Handing a token to a build command is handing it to arbitrary code, and secret masking doesn't stop a build script transforming a value it can read. Getting that right depended on a set of caveats that a later refactor could quietly undo.

Behind it sits a more general problem. `pages.yml` already carries `node-version`, `node-cache`, `go-version`, `go-version-file`, `install-command`, `test-setup-command`, `test-command` and `build-command`. Every build need this workflow didn't anticipate becomes another input and another PR here. **Deploying a directory is the reusable part; building it is what varies per repo.**

## What

One optional input, `artifact-name`. When set, the deploy jobs download that artifact into `artifact-path` and deploy it as-is, skipping Node/Go setup, install and build:

```yaml
jobs:
  build:
    permissions:
      contents: read
      issues: read              # whatever *your* build needs
    steps:
      - run: npm ci && npm test && npm run build
        env:
          GITHUB_TOKEN: ${{ github.token }}
      - uses: actions/upload-artifact@<sha>
        with: { name: site, path: dist }

  pages:
    needs: build
    uses: DevSecNinja/.github/.github/workflows/pages.yml@<sha>
    with:
      artifact-name: site
      artifact-path: dist
```

Artifacts are scoped to a workflow run, and a reusable workflow's jobs run *inside the caller's run* — so this needs no extra permissions and **no credential is passed into this workflow at all**. The build runs in the caller's own job, where the caller already controls permissions, secrets and tooling.

`artifact-name` and `build-command` are mutually exclusive, validated in `validate-inputs`. `build-command` mode is untouched — this is purely additive.

## Notes

- The `test` job is unaffected: it still runs `test-command` from a source checkout, including Go setup, since tests run from source even when the site is prebuilt.
- The same artifact is deployed to previews and production. A caller wanting previews built without credentials branches on `github.event_name` in its own build job — the decision now lives where it's visible.
- `actions/upload-artifact` v4+ omits hidden files unless `include-hidden-files: true`; relevant for `.well-known`, `.nojekyll`. Documented.
- Adds ~10–20s of artifact round-trip per deploy.

## Also included

- `docs/architecture.md`: the `artifact-name` input plus a worked "deploying a prebuilt artifact" example.
- `docs/design-decisions/0006-prebuilt-artifact-deploys.md` (ADR), recording the decision and why the token input, a generic `build-env`, more per-need inputs, committing fetched data, and unauthenticated API calls were all rejected.

## Verification

- `actionlint` and `yamllint` clean.
- Parsed the workflow and asserted step conditions per job: `Download prebuilt site` present in all three deploy jobs and gated on `artifact-name != ''`; `Build site` gated on `build-command`; `Setup Go` guarded by `artifact-name` in the deploy jobs but **not** in `test`.
- Backwards compatible: one new optional input, no secrets added, existing callers unchanged.

First consumer: DevSecNinja/bean-book#29, which builds two sites in one job and calls this workflow twice.
