### PR TITLE
fix(pages): scope Cloudflare concurrency per project

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -365,7 +365,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
-      group: pages-${{ github.repository }}
+      # Concurrency groups are already scoped to the repository, so naming the
+      # repo adds nothing. A repository has exactly one GitHub Pages site, so
+      # every call that deploys to Pages does belong in a single group.
+      group: pages
       cancel-in-progress: false
     environment:
       name: github-pages
@@ -488,7 +491,7 @@ jobs:
     concurrency:
       # Scoped per Cloudflare project: a repository may call this workflow once
       # per site, and those deploys are independent of each other.
-      group: cloudflare-pages-${{ matrix.target }}-${{ github.repository }}-${{ needs.detect-cloudflare.outputs.project-name }}
+      group: cloudflare-pages-${{ matrix.target }}-${{ needs.detect-cloudflare.outputs.project-name }}
       cancel-in-progress: false
     environment:
       name: ${{ matrix.environment }}
@@ -602,7 +605,7 @@ jobs:
       # Scoped per Cloudflare project, as above. Without the project name two
       # calls from one repository share a group and, because this one cancels
       # in progress, the second preview kills the first.
-      group: preview-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ needs.detect-cloudflare.outputs.project-name }}
+      group: preview-${{ github.event.pull_request.number }}-${{ needs.detect-cloudflare.outputs.project-name }}
       cancel-in-progress: true
     permissions:
       contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -486,7 +486,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
-      group: cloudflare-pages-${{ matrix.target }}-${{ github.repository }}
+      # Scoped per Cloudflare project: a repository may call this workflow once
+      # per site, and those deploys are independent of each other.
+      group: cloudflare-pages-${{ matrix.target }}-${{ github.repository }}-${{ needs.detect-cloudflare.outputs.project-name }}
       cancel-in-progress: false
     environment:
       name: ${{ matrix.environment }}
@@ -597,7 +599,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
-      group: preview-${{ github.repository }}-${{ github.event.pull_request.number }}
+      # Scoped per Cloudflare project, as above. Without the project name two
+      # calls from one repository share a group and, because this one cancels
+      # in progress, the second preview kills the first.
+      group: preview-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ needs.detect-cloudflare.outputs.project-name }}
       cancel-in-progress: true
     permissions:
       contents: read

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,6 +213,11 @@ jobs:
       cloudflare-project-name: my-site
 ```
 
+A repository may call this workflow more than once — once per site. Cloudflare
+deploy and preview concurrency is scoped per project name, so parallel calls do
+not cancel or serialise each other. Give each call its own
+`preview-comment-marker` so the preview comments don't overwrite one another.
+
 `artifact-name` and `build-command` are mutually exclusive — the artifact is
 deployed exactly as uploaded. With `artifact-name` set the deploy jobs skip
 Node/Go setup, install and build entirely.


### PR DESCRIPTION
## Why

A repository can call this workflow more than once — once per site. The Cloudflare concurrency groups were keyed on `github.repository` alone, so those independent calls landed in the *same* group:

| Job | Group (before) | Effect with two calls |
|-----|----------------|-----------------------|
| `deploy-preview` | `preview-<repo>-<pr>` | `cancel-in-progress: true` → **the second preview cancels the first** |
| `deploy-cloudflare` | `cloudflare-pages-<target>-<repo>` | independent production deploys serialise behind each other |

Caught for real in DevSecNinja/bean-book#29, which deploys two sites (`bean-book` and `leaf-book`) from one repo. Leaf Book's preview deployed fine; Bean Book's was cancelled with:

```
Canceling since a higher priority waiting request for preview-DevSecNinja/bean-book-29 exists
```

## What

Append the resolved `project-name` to the two Cloudflare groups. Both jobs already `needs: detect-cloudflare`, so the output is in scope, and `needs` is available in job-level `concurrency`.

Also **drop `${{ github.repository }}` from all three groups.** [Concurrency groups are already scoped to the repository](https://github.com/orgs/community/discussions/78332), so naming the repo added nothing — and with the project name appended it pushed both Cloudflare groups past yamlfmt's 120-column limit, where the formatter wrapped them mid-`${{ }}` expression. Removing it keeps them readable and the semantics identical.

| Job | Group (after) |
|-----|---------------|
| `deploy` | `pages` |
| `deploy-cloudflare` | `cloudflare-pages-<target>-<project>` |
| `deploy-preview` | `preview-<pr>-<project>` |

The GitHub Pages group stays a single group on purpose: a repository has exactly one Pages site, so serialising those deploys is correct.

## Notes

Single-call callers are unaffected in behaviour — their groups are just renamed, and nothing persists across runs keyed on the name.

Also documents that multi-call repos should give each call its own `preview-comment-marker`, so preview comments don't overwrite each other.

## Verification

- All 11 lint jobs green (this originally failed `yamlfmt`; reproduced locally with the pinned yamlfmt 0.21.0 and the org config).
- Asserted both jobs still `needs: detect-cloudflare` and that the new groups reference it.
