### PR TITLE
fix(renovate): recognize linuxserver version-v* tags

### DIFF
--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -77,8 +77,15 @@
       schedule: ["at any time"],
     },
     {
+      // The `v` prefix is matched outside `<major>`: capturing it (`v?\d+`) makes
+      // Renovate's Number.parseInt("v1") return NaN and corrupt version comparison.
+      // `<release>` is optional so three-part tags with no trailing build/release
+      // segment (e.g. bazarr's `version-v1.5.3`) match at all — when it was
+      // mandatory those tags never matched and were never updated, and tags like
+      // `version-10.4.57` backtracked into patch=5/release=7. `latest` is anchored
+      // with `$` so it cannot also match unrelated tags sharing that prefix.
       description: "Use custom versioning for linuxserver images",
-      versioning: "regex:^(version)(?<compatibility>.*?)-(?<major>v?\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[\\.-]*r?(?<build>\\d+)*-*r?(?<release>\\w+)|^latest*",
+      versioning: "regex:^(version)(?<compatibility>.*?)-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[\\.-]*r?(?<build>\\d+)*-*r?(?<release>\\w+)?|^latest$",
       matchPackageNames: ["/^lscr\\.io\\/linuxserver\\//"],
     },
     {


### PR DESCRIPTION
Renovate never bumped linuxserver images pinned to three-part `version-v*` tags — e.g. bazarr sat at `version-v1.5.3` and never moved to `version-v1.5.4`.

This is the upstream fix for the defect worked around locally in [DevSecNinja/truenas-apps#630](https://github.com/DevSecNinja/truenas-apps/pull/630). Fixing it here benefits every repo extending this preset; the local override in truenas-apps can be dropped once this merges.

## Defects

**1. Mandatory trailing `<release>` segment.** The regex ended in `(?<release>\w+)`, requiring a build/release suffix, so tags with nothing after the patch never matched.

It also caused silent misparsing via backtracking on tags that *did* match — `version-10.4.57` parsed as **patch=5, release=7**, corrupting comparison for `unifi-network-application`. That one was not previously reported.

**2. `v` captured inside `<major>`.** `(?<major>v?\d+)` captured `major="v1"`, which Renovate parses with `Number.parseInt` → `NaN`.

**3. Unanchored `latest`.** `^latest*` matches `lates`, `latestfoo`, etc.

## Change

```diff
-versioning: "regex:^(version)(?<compatibility>.*?)-(?<major>v?\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[\\.-]*r?(?<build>\\d+)*-*r?(?<release>\\w+)|^latest*",
+versioning: "regex:^(version)(?<compatibility>.*?)-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[\\.-]*r?(?<build>\\d+)*-*r?(?<release>\\w+)?|^latest$",
```

## Validation

Checked against every linuxserver tag shape in use, old vs new:

| Tag | Before | After |
| --- | --- | --- |
| `version-v1.5.3` (bazarr) | **NO MATCH** | major=1 minor=5 patch=3 |
| `version-10.4.57` (unifi) | major=10 minor=4 **patch=5** | major=10 minor=4 **patch=57** |
| `version-2.5.2.5491` (prowlarr) | major=2 minor=5 patch=2 | unchanged |
| `version-3.4.2-r0` (socket-proxy) | major=3 minor=4 patch=2 | unchanged |
| `version-1.43.3.10828-00f62d37d` (plex) | major=1 minor=43 patch=3 | unchanged |
| `version-3.1.0.4875` (lidarr) | major=3 minor=1 patch=0 | unchanged |
| `version-4.0.19.2979` (sonarr) | major=4 minor=0 patch=19 | unchanged |
| `version-6.3.0.10514` (radarr) | major=6 minor=3 patch=0 | unchanged |
| `latest` | matches | matches |
| `latestfoo` | matches (wrong) | no match |

`lscr.io/linuxserver/qbittorrent:5.1.4` matches neither regex (no `version-` prefix) and is unaffected — it continues to receive digest updates.

`renovate-config-validator` passes: `INFO: Config validated successfully`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>