### PR TITLE
fix(renovate): gate dhi.io behind the pr-cooldown soak

### DIFF
--- a/.github/workflows/renovate-pr-cooldown.yml
+++ b/.github/workflows/renovate-pr-cooldown.yml
@@ -30,7 +30,7 @@ on:
           a trusted release timestamp).
         required: false
         type: string
-        default: "renovate/ghcr.io-,renovate/lscr.io-,renovate/quay.io-"
+        default: "renovate/ghcr.io-,renovate/lscr.io-,renovate/quay.io-,renovate/dhi.io-"
       renovate-bot-login:
         description: "Login of the account that opens Renovate PRs."
         required: false

--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -53,12 +53,13 @@
       minimumReleaseAge: "14 days",
     },
     {
-      description: "ghcr.io / lscr.io / quay.io do not expose a trusted release timestamp, so the default timestamp-required behaviour marks every release 'pending' forever and no PR is ever created. Treat missing timestamps as stable so Renovate opens the PR (and enables automerge); the 14-day soak is instead enforced by the pr-cooldown required status check, which measures the PR branch head commit age. rebaseWhen:conflicted stops behind-base-branch rebases from rewriting that commit on every base change and perpetually resetting the cooldown clock (branch protection is non-strict, so a behind-base branch still auto-merges once soaked). Placed after the generic docker rule so it wins. See docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.",
+      description: "ghcr.io / lscr.io / quay.io / dhi.io do not expose a trusted release timestamp, so the default timestamp-required behaviour marks every release 'pending' forever and no PR is ever created. Treat missing timestamps as stable so Renovate opens the PR (and enables automerge); the 14-day soak is instead enforced by the pr-cooldown required status check, which measures the PR branch head commit age. rebaseWhen:conflicted stops behind-base-branch rebases from rewriting that commit on every base change and perpetually resetting the cooldown clock (branch protection is non-strict, so a behind-base branch still auto-merges once soaked). Placed after the generic docker rule so it wins. See docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.",
       matchDatasources: ["docker"],
       matchPackageNames: [
         "/^ghcr\\.io\\//",
         "/^lscr\\.io\\//",
         "/^quay\\.io\\//",
+        "/^dhi\\.io\\//",
       ],
       minimumReleaseAgeBehaviour: "timestamp-optional",
       rebaseWhen: "conflicted",

--- a/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
+++ b/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
@@ -17,8 +17,9 @@ datasource/registry must provide. Renovate 42+ defaults
 **not** trust the OCI `org.opencontainers.image.created` annotation (the
 publisher controls it, so it could be forged to bypass the soak).
 
-Several registries we use — **ghcr.io, lscr.io, quay.io** — expose no trusted
-timestamp. With `timestamp-required`, every release from those registries is
+Several registries we use — **ghcr.io, lscr.io, quay.io, dhi.io** — expose no
+trusted timestamp. With `timestamp-required`, every release from those
+registries is
 marked "pending" forever: `internalChecksFilter: strict` then refuses to create
 a branch, so the update sits under the dependency dashboard's "Pending Status
 Checks" section and **no PR is ever opened** (observed in
@@ -43,7 +44,7 @@ The two native options are both unacceptable on their own:
 Keep the soak, but for these registries **measure it from PR age instead of
 release age**.
 
-1. For `docker` deps on `ghcr.io` / `lscr.io` / `quay.io`, set
+1. For `docker` deps on `ghcr.io` / `lscr.io` / `quay.io` / `dhi.io`, set
    `minimumReleaseAgeBehaviour: "timestamp-optional"` (in
    [`.renovate/packageRules.json5`](../../.renovate/packageRules.json5)). Renovate
    opens the PR immediately and enables `platformAutomerge`.


### PR DESCRIPTION
`dhi.io` exposes no trusted release timestamp — same as `ghcr.io`, `lscr.io` and `quay.io` — but it was never added to the [ADR 0005](docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md) wiring.

Found while diagnosing [DevSecNinja/truenas-apps#634](https://github.com/DevSecNinja/truenas-apps/issues/634), where all four `dhi.io` hardened images have received no updates at all for ~3.5 months.

## Why both changes must land together

| Gap | Consequence |
| --- | --- |
| Not in the `timestamp-optional` rule | Stays on default `timestamp-required` + `internalChecksFilter: strict` → every release marked pending forever, **no PR ever opened** — the exact failure ADR 0005 was written to solve |
| Not in `gated-branch-prefixes` | `pr-cooldown` returns `No cooldown required` → **zero soak** with automerge enabled |

Fixing only the first would restore updates that auto-merge with no soak at all, on the images specifically chosen for their security posture. Fixing only the second does nothing. So both change in one PR.

## Changes

- `.renovate/packageRules.json5` — add `/^dhi\.io\//` to the `timestamp-optional` rule and update its description.
- `.github/workflows/renovate-pr-cooldown.yml` — add `renovate/dhi.io-` to the default `gated-branch-prefixes`.
- `docs/design-decisions/0005-*.md` — add `dhi.io` to the registry list so the ADR matches the implementation.

## Validation

`renovate-config-validator`: `INFO: Config validated successfully`

Resolved the merged rule set through Renovate's own `applyPackageRules`:

| Package | `minimumReleaseAgeBehaviour` | `rebaseWhen` |
| --- | --- | --- |
| `dhi.io/traefik` | `timestamp-optional` | `conflicted` |
| `ghcr.io/gethomepage/homepage` | `timestamp-optional` | `conflicted` |
| `docker.io/library/mongo` | *(default `timestamp-required`)* | *(default)* |

`dhi.io` now matches the other timestamp-less registries; `docker.io` keeps its native soak. `yamllint -c config-sync/files/.yamllint.yaml` clean on the changed workflow.

## Note for consuming repos

Any repo that already passes an explicit `gated-branch-prefixes` input overrides this default and will need `renovate/dhi.io-` added locally. `truenas-apps` relies on the default, so it picks this up automatically.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>