### PR TITLE
feat(renovate): derive timestamp gating from one matcher

### DIFF
--- a/.github/workflows/renovate-pr-cooldown.yml
+++ b/.github/workflows/renovate-pr-cooldown.yml
@@ -26,11 +26,13 @@ on:
         default: 14
       gated-branch-prefixes:
         description: >-
-          Comma-separated Renovate branch prefixes to gate (registries without
-          a trusted release timestamp).
+          Comma-separated Renovate branch prefixes to gate. The default matches
+          the `docker-gated-` marker that .renovate/packageRules.json5 stamps
+          onto every dependency Renovate cannot soak natively, so the gate and
+          the Renovate config are driven by one shared decision.
         required: false
         type: string
-        default: "renovate/ghcr.io-,renovate/lscr.io-,renovate/quay.io-"
+        default: "renovate/docker-gated-"
       renovate-bot-login:
         description: "Login of the account that opens Renovate PRs."
         required: false
@@ -73,6 +75,8 @@ jobs:
             const { owner, repo } = context.repo;
             const dayMs = 24 * 60 * 60 * 1000;
 
+            // The `docker-gated-` marker is applied by the same Renovate rule
+            // that sets timestamp-optional, so this can never drift from it.
             const isGated = (branch) =>
               prefixes.some((prefix) => branch.startsWith(prefix));
 

--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -53,15 +53,32 @@
       minimumReleaseAge: "14 days",
     },
     {
-      description: "ghcr.io / lscr.io / quay.io do not expose a trusted release timestamp, so the default timestamp-required behaviour marks every release 'pending' forever and no PR is ever created. Treat missing timestamps as stable so Renovate opens the PR (and enables automerge); the 14-day soak is instead enforced by the pr-cooldown required status check, which measures the PR branch head commit age. rebaseWhen:conflicted stops behind-base-branch rebases from rewriting that commit on every base change and perpetually resetting the cooldown clock (branch protection is non-strict, so a behind-base branch still auto-merges once soaked). Placed after the generic docker rule so it wins. See docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.",
+      // Renovate only derives a release timestamp for Docker Hub, and only via
+      // the Hub-specific hub.docker.com API — `registryHost === DOCKER_HUB` in
+      // the docker datasource. Every other registry goes through the OCI
+      // Registry V2 /tags/list endpoint, which returns bare tag names, so no
+      // timestamp exists regardless of what the registry stores internally.
+      // Match that condition directly instead of maintaining an allowlist:
+      // previously each new registry had to be remembered here AND in the
+      // cooldown workflow, and dhi.io was missing from both for ~3.5 months
+      // (DevSecNinja/truenas-apps#634).
+      // The positive pattern requires a dot in the first path segment, i.e. an
+      // explicit registry host, so bare Docker Hub names like "nginx" or
+      // "library/nginx" keep their native soak.
+      // The same matcher also stamps the branch name, so the cooldown gate and
+      // this rule can never disagree: any dep Renovate cannot soak natively
+      // gets `renovate/docker-gated-`, and the workflow gates exactly that
+      // prefix. A registry nobody has wired up yet is therefore gated by
+      // default rather than auto-merging unsoaked.
+      description: "Every registry except Docker Hub lacks a trusted release timestamp, so the default timestamp-required behaviour marks every release 'pending' forever and no PR is ever created. Treat missing timestamps as stable so Renovate opens the PR (and enables automerge); the 14-day soak is instead enforced by the pr-cooldown required status check, which measures the PR branch head commit age. rebaseWhen:conflicted stops behind-base-branch rebases from rewriting that commit on every base change and perpetually resetting the cooldown clock (branch protection is non-strict, so a behind-base branch still auto-merges once soaked). Placed after the generic docker rule so it wins. See docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md.",
       matchDatasources: ["docker"],
       matchPackageNames: [
-        "/^ghcr\\.io\\//",
-        "/^lscr\\.io\\//",
-        "/^quay\\.io\\//",
+        "/^[^/]*\\./",
+        "!/^docker\\.io\\//",
       ],
       minimumReleaseAgeBehaviour: "timestamp-optional",
       rebaseWhen: "conflicted",
+      additionalBranchPrefix: "docker-gated-",
     },
     {
       description: "Auto-merge dotfiles devcontainer image digest, patch, and minor updates via branch without tests, ignoring the global schedule and release-age soak so they can always merge. Placed after the generic docker minimumReleaseAge rule so its minimumReleaseAge:0 wins. Major bumps are intentionally excluded and left for manual review.",

--- a/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
+++ b/docs/design-decisions/0005-pr-age-cooldown-for-untrusted-timestamps.md
@@ -17,8 +17,16 @@ datasource/registry must provide. Renovate 42+ defaults
 **not** trust the OCI `org.opencontainers.image.created` annotation (the
 publisher controls it, so it could be forged to bypass the soak).
 
-Several registries we use — **ghcr.io, lscr.io, quay.io** — expose no trusted
-timestamp. With `timestamp-required`, every release from those registries is
+Renovate only derives a release timestamp for **Docker Hub**, and only via the
+Hub-specific `hub.docker.com` API (`registryHost === DOCKER_HUB` in the docker
+datasource). Every other registry is read through the OCI Registry V2
+`/tags/list` endpoint, which returns bare tag names, so **no timestamp exists
+regardless of what the registry stores internally** — this is a Renovate
+limitation keyed on the registry host, not an omission by any given registry.
+
+Registries we use that are affected include **ghcr.io, lscr.io, quay.io,
+dhi.io, mcr.microsoft.com**. With `timestamp-required`, every release from
+those registries is
 marked "pending" forever: `internalChecksFilter: strict` then refuses to create
 a branch, so the update sits under the dependency dashboard's "Pending Status
 Checks" section and **no PR is ever opened** (observed in
@@ -43,10 +51,19 @@ The two native options are both unacceptable on their own:
 Keep the soak, but for these registries **measure it from PR age instead of
 release age**.
 
-1. For `docker` deps on `ghcr.io` / `lscr.io` / `quay.io`, set
+1. For `docker` deps on **every registry except Docker Hub**, set
    `minimumReleaseAgeBehaviour: "timestamp-optional"` (in
    [`.renovate/packageRules.json5`](../../.renovate/packageRules.json5)). Renovate
    opens the PR immediately and enables `platformAutomerge`.
+
+   This is expressed as a negated matcher (`/^[^/]*\./` plus
+   `!/^docker\.io\//`) rather than a list of registries, mirroring Renovate's
+   own internal condition. The positive pattern requires a dot in the first
+   path segment — an explicit registry host — so bare Docker Hub names such as
+   `nginx` keep their native soak. An allowlist was the original design and it
+   failed silently: `dhi.io` was never added, and its images went ~3.5 months
+   with no updates at all (`DevSecNinja/truenas-apps#634`). A registry nobody
+   has wired up is now gated by default rather than slipping through.
 2. A required **`pr-cooldown`** status check holds the merge until the PR branch
    head commit is at least 14 days old, provided by the reusable workflow
    [`renovate-pr-cooldown.yml`](../../.github/workflows/renovate-pr-cooldown.yml).
@@ -81,6 +98,14 @@ A repo that hosts images from the gated registries must:
    checks**. The workflow reports `success` for human and non-gated PRs, so the
    required check never blocks anything else.
 
+A repo that passes an explicit `gated-branch-prefixes` input (rather than
+relying on the default) must switch it to `renovate/docker-gated-`, otherwise
+its gate will look for branch names Renovate no longer produces.
+
+Because the marker changes branch naming, open Renovate PRs for non-Docker-Hub
+images are recreated once under the new prefix; their cooldown clock restarts.
+Docker Hub branches are unaffected.
+
 ## Alternatives considered
 
 - **`timestamp-optional` alone.** Rejected: removes the soak for exactly the
@@ -93,10 +118,17 @@ A repo that hosts images from the gated registries must:
 - **Gate every registry (incl. docker.io) with `pr-cooldown`.** Rejected:
   double-soaks images that already have a trusted timestamp; only registries
   without one need the PR-age fallback.
+- **Keep an allowlist of timestamp-less registries.** Rejected: it must be kept
+  in sync in two places (the Renovate rule and the workflow's branch prefixes),
+  and a registry missing from both fails silently. Inverting only the Renovate
+  half would be worse still — the dep would get `timestamp-optional` while the
+  gate ignored its branch, auto-merging with **zero** soak. Both halves are now
+  driven by one matcher via the `docker-gated-` branch marker, so they cannot
+  drift apart.
 
 ## Consequences
 
-- Updates from ghcr.io / lscr.io / quay.io flow again and auto-merge after a
+- Updates from every timestamp-less registry flow again and auto-merge after a
   14-day PR-age soak, preserving the ADR 0004 risk posture without trusting a
   forgeable timestamp.
 - The soak clock for these registries starts when Renovate first opens (or last


### PR DESCRIPTION
**Supersedes #311.** Same goal — get `dhi.io` soaked correctly — but fixes the class of bug instead of the instance.

## The problem with the allowlist

The ADR 0005 fallback was encoded as **two hand-maintained allowlists** that had to stay in sync:

- registries in `.renovate/packageRules.json5`
- branch prefixes in `renovate-pr-cooldown.yml`

`dhi.io` was missing from both for ~3.5 months and nothing detected it ([truenas-apps#634](https://github.com/DevSecNinja/truenas-apps/issues/634)).

## Why inverting only half would be dangerous

Worth being explicit, because the obvious fix is a trap:

| | Unknown registry before | If only packageRules were inverted |
| --- | --- | --- |
| `timestamp-optional`? | No → `timestamp-required` + strict | **Yes** |
| Branch gated? | No | **Still no** |
| Result | No PRs ever — stale, but never unsoaked | No native timestamp **and** `No cooldown required` → **auto-merge, zero soak** |

Today an unknown registry fails *safe*; a one-sided inversion makes it fail *unsafe*.

## Approach

Match Renovate's own condition. It derives a release timestamp only for Docker Hub, and only via the Hub-specific `hub.docker.com` API (`registryHost === DOCKER_HUB`); every other registry is read through Registry V2 `/tags/list`, which returns bare tag names. So the real predicate is "is this Docker Hub", not "is this one of N registries I remembered".

**The same rule that sets `timestamp-optional` also stamps `additionalBranchPrefix: "docker-gated-"`**, and the workflow gates exactly that prefix. One decision drives both halves, so they cannot drift — which removes the failure mode rather than patching this instance of it.

```json5
matchDatasources: ["docker"],
matchPackageNames: ["/^[^/]*\\./", "!/^docker\\.io\\//"],
minimumReleaseAgeBehaviour: "timestamp-optional",
rebaseWhen: "conflicted",
additionalBranchPrefix: "docker-gated-",
```

The positive pattern requires a dot in the first path segment (an explicit registry host), so bare Docker Hub names like `nginx` keep their native soak rather than being double-soaked.

## Validation

Resolved the real rule set through Renovate's own `applyPackageRules` and checked the gate agrees in every case — **0 mismatches**:

| Package | Behaviour | Branch | Gated | Agrees |
| --- | --- | --- | --- | --- |
| `docker.io/library/mongo` | native | `renovate/docker.io-…` | false | yes |
| `ghcr.io/foo/bar` | timestamp-optional | `renovate/docker-gated-…` | true | yes |
| `dhi.io/traefik` | timestamp-optional | `renovate/docker-gated-…` | true | yes |
| `lscr.io/x/y` | timestamp-optional | `renovate/docker-gated-…` | true | yes |
| `quay.io/x/y` | timestamp-optional | `renovate/docker-gated-…` | true | yes |
| `mcr.microsoft.com/devcontainers/base` | timestamp-optional | `renovate/docker-gated-…` | true | yes |
| **`newregistry.example.com/a/b`** | timestamp-optional | `renovate/docker-gated-…` | **true** | yes |
| `nginx` | native | `renovate/nginx-1.x` | false | yes |
| `library/nginx` | native | `renovate/library-nginx-1.x` | false | yes |
| `actions/checkout` (github-tags) | native | `renovate/actions-checkout-…` | false | yes |
| `jdx/mise` (github-releases) | native | `renovate/jdx-mise-…` | false | yes |

Note `newregistry.example.com` — a registry nobody has wired up is now gated **by default**. That is the whole point.

Also: `renovate-config-validator` passes, `yamllint -c config-sync/files/.yamllint.yaml` clean, workflow YAML parses, and the `github-script` body passes `node --check`.

## Migration

- No repo currently passes an explicit `gated-branch-prefixes`, so all consumers pick up the new default automatically. Any repo that starts overriding it must use `renovate/docker-gated-`.
- Open Renovate PRs for non-Docker-Hub images are recreated once under the new prefix and their cooldown clock restarts. Docker Hub branches are unchanged, so that churn is limited.
- ADR 0005 updated: the Renovate-side reason for the missing timestamps, the negated matcher, the rejected allowlist alternative, and the migration note.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>