### PR TITLE
fix(renovate): scope linuxserver versioning by mirror and tag shape

### DIFF
--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -103,7 +103,24 @@
       // with `$` so it cannot also match unrelated tags sharing that prefix.
       description: "Use custom versioning for linuxserver images",
       versioning: "regex:^(version)(?<compatibility>.*?)-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[\\.-]*r?(?<build>\\d+)*-*r?(?<release>\\w+)?|^latest$",
-      matchPackageNames: ["/^lscr\\.io\\/linuxserver\\//"],
+      // linuxserver publishes the same images to Docker Hub, lscr.io and ghcr.io
+      // with identical digests. Docker Hub is preferred because it is the only
+      // registry Renovate reads a release timestamp from, so the soak is
+      // enforced natively there rather than by the pr-cooldown proxy — but the
+      // rule must cover every mirror, otherwise moving an image between them
+      // silently changes its versioning.
+      matchPackageNames: [
+        "/^lscr\\.io\\/linuxserver\\//",
+        "/^docker\\.io\\/linuxserver\\//",
+        "/^ghcr\\.io\\/linuxserver\\//",
+      ],
+      // Only `version-*` tags need this regex. Some linuxserver images (e.g.
+      // qbittorrent) publish plain semver tags like `5.1.4`, which the regex
+      // cannot parse — forcing it on them makes the value uncomparable, so they
+      // get digest-only updates and silently freeze. Selecting on tag shape
+      // instead of image name lets those fall through to default docker
+      // versioning, which compares them correctly, with no per-image allowlist.
+      matchCurrentValue: "/^version-/",
     },
     {
       description: "Group .chezmoiversion and .mise.toml chezmoi pin updates into one PR so both files are always updated atomically and CI stays green.",


### PR DESCRIPTION
Prerequisite for moving linuxserver images to Docker Hub in `truenas-apps`, and fixes [truenas-apps#610](https://github.com/DevSecNinja/truenas-apps/issues/610) on the way.

## Problem 1 — the rule matched only `lscr.io`

```json5
matchPackageNames: ["/^lscr\\.io\\/linuxserver\\//"],
```

Docker Hub is the preferred mirror: it is the only registry Renovate reads a release timestamp from, so `minimumReleaseAge` is enforced **natively** there rather than by the `pr-cooldown` branch-age proxy. But moving an image to `docker.io` silently dropped it out of this rule, changing its versioning without any signal.

linuxserver publishes the same images to all three mirrors with **identical digests** — verified per tag:

| Image | tag | ghcr.io vs docker.io |
| --- | --- | --- |
| `lidarr` | `version-3.1.0.4875` | identical |
| `sonarr` | `version-4.0.19.2979` | identical |
| `radarr` | `version-6.3.0.10514` | identical |
| `prowlarr` | `version-2.5.2.5491` | identical |
| `unifi-network-application` | `version-10.4.57` | identical |
| `plex` | `version-1.43.3.10828-…` | identical |

So the rule should follow the image, not the registry.

## Problem 2 — not every linuxserver image uses `version-*`

qbittorrent publishes plain semver (`5.1.4`); its `version-*` tags are a legacy 2021 scheme (`version-14.3.9.99202110311443-7435-…ubuntu20.04.1`). Forcing the regex onto it made the current value unparseable, so it became uncomparable and only ever received digest updates — which the shared config disables. It froze at `5.1.4` while **5.2.3** shipped.

Default docker versioning handles it correctly:

```
isValid('5.1.4')                    -> true
isGreaterThan('5.2.3', '5.1.4')     -> true
```

## Change

Cover all three mirrors, and select on **tag shape** rather than image name:

```json5
matchPackageNames: [
  "/^lscr\\.io\\/linuxserver\\//",
  "/^docker\\.io\\/linuxserver\\//",
  "/^ghcr\\.io\\/linuxserver\\//",
],
matchCurrentValue: "/^version-/",
```

Images self-select: `version-*` gets the regex, plain semver falls through to the default. No per-image allowlist to drift — same principle as #312.

## Validation

`renovate-config-validator` passes. Resolved through `applyPackageRules`:

| Package | Tag | Versioning |
| --- | --- | --- |
| `docker.io/linuxserver/sabnzbd` | `version-5.0.4` | regex |
| `lscr.io/linuxserver/sonarr` | `version-4.0.19.2979` | regex |
| `ghcr.io/linuxserver/radarr` | `version-6.3.0.10514` | regex |
| `docker.io/linuxserver/qbittorrent` | `5.2.3` | default docker |
| `lscr.io/linuxserver/qbittorrent` | `5.1.4` | default docker |
| `docker.io/library/nginx` | `1.2.3` | default docker |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>