### PR TITLE
refactor(renovate): use build type for deps and add changelog sections

### DIFF
--- a/.renovate/semanticCommits.json5
+++ b/.renovate/semanticCommits.json5
@@ -2,34 +2,12 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
-      matchUpdateTypes: ["major"],
-      semanticCommitType: "feat",
-      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
-      commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
-    },
-    {
-      matchUpdateTypes: ["minor"],
-      semanticCommitType: "feat",
-      commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
-    },
-    {
-      matchUpdateTypes: ["patch"],
-      semanticCommitType: "fix",
-      commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
-    },
-    {
-      matchUpdateTypes: ["digest"],
-      semanticCommitType: "chore",
-      commitMessageExtra: "( {{currentDigestShort}} ➔ {{newDigestShort}} )",
-    },
-    {
       matchDatasources: ["docker"],
       semanticCommitScope: "container",
       commitMessageTopic: "image {{depName}}",
     },
     {
       matchManagers: ["github-actions"],
-      semanticCommitType: "ci",
       semanticCommitScope: "github-action",
       commitMessageTopic: "action {{depName}}",
     },

--- a/config-sync/files/renovate.json5
+++ b/config-sync/files/renovate.json5
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigests",
     ":dependencyDashboard",
     ":semanticCommits",
+    ":semanticCommitTypeAll(build)",
     "github>DevSecNinja/.github//.renovate/autoMerge.json5",
     "github>DevSecNinja/.github//.renovate/base.json5",
     "github>DevSecNinja/.github//.renovate/customManagers.json5",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,19 @@
   "draft": false,
   "draft-pull-request": false,
   "prerelease": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "🚀 Features" },
+    { "type": "fix", "section": "🐛 Bug Fixes" },
+    { "type": "perf", "section": "⚡ Performance" },
+    { "type": "revert", "section": "⏪ Reverts" },
+    { "type": "build", "section": "📦 Dependencies" },
+    { "type": "ci", "section": "🔧 CI", "hidden": true },
+    { "type": "docs", "section": "📖 Documentation", "hidden": true },
+    { "type": "chore", "hidden": true },
+    { "type": "refactor", "hidden": true },
+    { "type": "test", "hidden": true },
+    { "type": "style", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "simple",

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
+    ":semanticCommits",
+    ":semanticCommitTypeAll(build)",
     "github>DevSecNinja/.github//.renovate/autoMerge.json5",
     "github>DevSecNinja/.github//.renovate/base.json5",
     "github>DevSecNinja/.github//.renovate/customManagers.json5",


### PR DESCRIPTION
## Summary

Cleans up Renovate's semantic commit configuration to stop inflating changelogs with fake `feat`/`fix` entries for dependency updates. Instead, all dependency updates now use the `build` commit type, which release-please maps to a dedicated "📦 Dependencies" section at the bottom of changelogs.

## Changes

- **`.renovate/semanticCommits.json5`** — Removed `semanticCommitType` overrides (`feat`/`fix`/`ci`) and `commitMessageExtra` templates. Kept only the datasource/manager-specific `semanticCommitScope` and `commitMessageTopic` rules for readable PR titles.
- **`renovate.json5`** — Added `:semanticCommits` and `:semanticCommitTypeAll(build)` presets.
- **`config-sync/files/renovate.json5`** — Added `:semanticCommitTypeAll(build)` (already had `:semanticCommits`).
- **`release-please-config.json`** — Added `changelog-sections` with a "📦 Dependencies" section for `build` type commits, keeping `feat`/`fix`/`perf` visible and hiding `chore`/`ci`/`docs`/`refactor`/`test`/`style`.

## Result

Renovate PRs will read like:
```
build(github-action): update action actions/checkout
build(container): update image nginx
build(mise): update tool terraform
```

And appear in changelogs under:
```markdown
### 📦 Dependencies
- update action actions/checkout
- update image nginx
```

## Why

- `feat` for a minor dep bump is misleading — it's not a feature we shipped
- `fix` for a patch bump is misleading — it's not a bug we fixed
- `build` is semantically correct (changes affecting build/deps) per the Conventional Commits spec
- Renovate's default is `chore` which hides deps entirely — `build` gives visibility without noise