### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Adds an `.editorconfig` to standardize formatting across editors and CI tools.

## Problem

PR #240 fails the `lint / shfmt` check because `shfmt` defaults to tab indentation, while our org conventions specify 4-space indent for shell scripts. Without an `.editorconfig`, there's no single source of truth for formatting rules.

## Solution

`shfmt` automatically reads `.editorconfig`, so this file ensures CI enforces 4-space indent for `.sh` files — matching the org coding standards — without needing to pass `-i 4` flags in every workflow invocation.

### Settings applied

| Pattern | Style | Size |
|---------|-------|------|
| `*` | LF endings, final newline, UTF-8 | — |
| `*.{yml,yaml,json}` | spaces | 2 |
| `*.md` | spaces | 4 |
| `*.sh` | spaces | 4 |
| `Makefile` | tabs | — |

## Related

- Fixes the `shfmt` failure in #240
- Standardizes formatting expectations for any repo consuming this `.editorconfig`